### PR TITLE
Don't sign commits from patches in sysroot

### DIFF
--- a/build_sysroot/prepare_sysroot_src.sh
+++ b/build_sysroot/prepare_sysroot_src.sh
@@ -24,7 +24,7 @@ git commit -m "Initial commit" -q
 for file in $(ls ../../patches/ | grep -v patcha); do
 echo "[GIT] apply" $file
 git apply ../../patches/$file
-git commit -am "Patch $file"
+git commit --no-gpg-sign -am "Patch $file"
 done
 popd
 


### PR DESCRIPTION
I have commit signing enabled by default globally, so whenever I prepare the sysroot it asks me to unlock my GPG key. A signature is unnecessary here anyway, so disable them with `--no-gpg-sign`.