### PR TITLE
Simd emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ perf.data.old
 /build_sysroot/sysroot_src
 /build_sysroot/Cargo.lock
 /rust
+/regex

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ $ RUSTFLAGS="-Cpanic=abort -Zcodegen-backend=$cg_clif_dir/target/debug/librustc_
 * Good non-rust abi support ([vectors are passed by-ref](https://github.com/bjorn3/rustc_codegen_cranelift/issues/10))
 * Checked binops ([some missing instructions in cranelift](https://github.com/CraneStation/cranelift/issues/460))
 * Inline assembly ([no cranelift support](https://github.com/CraneStation/cranelift/issues/444))
-* SIMD ([tracked here](https://github.com/bjorn3/rustc_codegen_cranelift/issues/171))
+* SIMD ([tracked here](https://github.com/bjorn3/rustc_codegen_cranelift/issues/171), some basic things work)
 
 ## Troubleshooting
 

--- a/cargo.sh
+++ b/cargo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -z $CHANNEL ]; then
+export CHANNEL='debug'
+fi
+
+pushd $(dirname "$0") >/dev/null
+source config.sh
+popd >/dev/null
+
+cmd=$1
+shift
+
+cargo $cmd --target $TARGET_TRIPLE $@

--- a/clean_all.sh
+++ b/clean_all.sh
@@ -2,3 +2,4 @@
 set -e
 
 rm -rf target/ build_sysroot/{sysroot/,sysroot_src/,target/,Cargo.lock} perf.data{,.old}
+rm -rf regex/

--- a/config.sh
+++ b/config.sh
@@ -10,14 +10,8 @@ else
    exit 1
 fi
 
-if [[ "$1" == "--release" ]]; then
-    channel='release'
-    cargo build --release
-else
-    channel='debug'
-    cargo build
-fi
+TARGET_TRIPLE=$(rustc -vV | grep host | cut -d: -f2 | tr -d " ")
 
-export RUSTFLAGS='-Zalways-encode-mir -Cpanic=abort -Cdebuginfo=2 -Zcodegen-backend='$(pwd)'/target/'$channel'/librustc_codegen_cranelift.'$dylib_ext' --sysroot '$(pwd)'/build_sysroot/sysroot'
+export RUSTFLAGS='-Zalways-encode-mir -Cpanic=abort -Cdebuginfo=2 -Zcodegen-backend='$(pwd)'/target/'$CHANNEL'/librustc_codegen_cranelift.'$dylib_ext' --sysroot '$(pwd)'/build_sysroot/sysroot'
 RUSTC="rustc $RUSTFLAGS -L crate=target/out --out-dir target/out"
 export RUSTC_LOG=warn # display metadata load errors

--- a/crate_patches/regex.patch
+++ b/crate_patches/regex.patch
@@ -1,0 +1,34 @@
+From febff2a8c639efb5de1e1b4758cdb473847d80ce Mon Sep 17 00:00:00 2001
+From: bjorn3 <bjorn3@users.noreply.github.com>
+Date: Tue, 30 Jul 2019 12:12:37 +0200
+Subject: [PATCH] Disable threads in shootout-regex-dna example
+
+---
+ examples/shootout-regex-dna.rs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/examples/shootout-regex-dna.rs b/examples/shootout-regex-dna.rs
+index 2171bb3..37382f8 100644
+--- a/examples/shootout-regex-dna.rs
++++ b/examples/shootout-regex-dna.rs
+@@ -37,7 +37,7 @@ fn main() {
+     for variant in variants {
+         let seq = seq_arc.clone();
+         let restr = variant.to_string();
+-        let future = thread::spawn(move || variant.find_iter(&seq).count());
++        let future = variant.find_iter(&seq).count();
+         counts.push((restr, future));
+     }
+ 
+@@ -60,7 +60,7 @@ fn main() {
+     }
+ 
+     for (variant, count) in counts {
+-        println!("{} {}", variant, count.join().unwrap());
++        println!("{} {}", variant, count);
+     }
+     println!("\n{}\n{}\n{}", ilen, clen, seq.len());
+ }
+-- 
+2.11.0
+

--- a/example/mini_core_hello_world.rs
+++ b/example/mini_core_hello_world.rs
@@ -117,12 +117,22 @@ impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsiz
 fn take_f32(_f: f32) {}
 fn take_unique(_u: Unique<()>) {}
 
+fn return_u128_pair() -> (u128, u128) {
+    (0, 0)
+}
+
+fn call_return_u128_pair() {
+    return_u128_pair();
+}
+
 fn main() {
     take_unique(Unique {
         pointer: 0 as *const (),
         _marker: PhantomData,
     });
     take_f32(0.1);
+
+    call_return_u128_pair();
 
     //return;
 

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -59,10 +59,12 @@ unsafe fn test_simd() {
     let or = _mm_or_si128(x, y);
     let cmp_eq = _mm_cmpeq_epi8(y, y);
     let cmp_lt = _mm_cmplt_epi8(y, y);
+    let shl = _mm_slli_si128(y, 1);
 
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 7]);
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_eq), [0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff]);
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_lt), [0, 0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 0]);
 }
 
 #[derive(PartialEq)]

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -65,6 +65,8 @@ unsafe fn test_simd() {
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_lt), [0, 0, 0, 0, 0, 0, 0, 0]);
 
     test_mm_slli_si128();
+    test_mm_movemask_epi8();
+    test_mm256_movemask_epi8();
 }
 
 #[target_feature(enable = "sse2")]
@@ -107,6 +109,31 @@ unsafe fn test_mm_slli_si128() {
     );
     let r = _mm_slli_si128(a, -0x80000000);
     assert_eq_m128i(r, _mm_set1_epi8(0));
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn test_mm_movemask_epi8() {
+    use std::arch::x86_64::*;
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        0b1000_0000u8 as i8, 0b0, 0b1000_0000u8 as i8, 0b01,
+        0b0101, 0b1111_0000u8 as i8, 0, 0,
+        0, 0, 0b1111_0000u8 as i8, 0b0101,
+        0b01, 0b1000_0000u8 as i8, 0b0, 0b1000_0000u8 as i8,
+    );
+    let r = _mm_movemask_epi8(a);
+    assert_eq!(r, 0b10100100_00100101);
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn test_mm256_movemask_epi8() {
+    use std::arch::x86_64::*;
+
+    let a = _mm256_set1_epi8(-1);
+    let r = _mm256_movemask_epi8(a);
+    let e = -1;
+    assert_eq!(r, e);
 }
 
 fn assert_eq_m128i(x: std::arch::x86_64::__m128i, y: std::arch::x86_64::__m128i) {

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -57,8 +57,12 @@ unsafe fn test_simd() {
     let x = _mm_setzero_si128();
     let y = _mm_set1_epi16(7);
     let or = _mm_or_si128(x, y);
+    let cmp_eq = _mm_cmpeq_epi8(y, y);
+    let cmp_lt = _mm_cmplt_epi8(y, y);
 
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 7]);
+    assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_eq), [0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff]);
+    assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_lt), [0, 0, 0, 0, 0, 0, 0, 0]);
 }
 
 #[derive(PartialEq)]

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -67,6 +67,9 @@ unsafe fn test_simd() {
     test_mm_slli_si128();
     test_mm_movemask_epi8();
     test_mm256_movemask_epi8();
+
+    let mask1 = _mm_movemask_epi8(dbg!(_mm_setr_epi8(255u8 as i8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    assert_eq!(mask1, 1);
 }
 
 #[target_feature(enable = "sse2")]

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -1,5 +1,6 @@
 #![feature(core_intrinsics)]
 
+use std::arch::x86_64::*;
 use std::io::Write;
 use std::intrinsics;
 
@@ -52,8 +53,6 @@ fn main() {
 
 #[target_feature(enable = "sse2")]
 unsafe fn test_simd() {
-    use std::arch::x86_64::*;
-
     let x = _mm_setzero_si128();
     let y = _mm_set1_epi16(7);
     let or = _mm_or_si128(x, y);
@@ -67,6 +66,8 @@ unsafe fn test_simd() {
     test_mm_slli_si128();
     test_mm_movemask_epi8();
     test_mm256_movemask_epi8();
+    test_mm_add_epi8();
+    test_mm_add_pd();
 
     let mask1 = _mm_movemask_epi8(dbg!(_mm_setr_epi8(255u8 as i8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
     assert_eq!(mask1, 1);
@@ -74,8 +75,6 @@ unsafe fn test_simd() {
 
 #[target_feature(enable = "sse2")]
 unsafe fn test_mm_slli_si128() {
-    use std::arch::x86_64::*;
-
     #[rustfmt::skip]
     let a = _mm_setr_epi8(
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -116,8 +115,6 @@ unsafe fn test_mm_slli_si128() {
 
 #[target_feature(enable = "sse2")]
 unsafe fn test_mm_movemask_epi8() {
-    use std::arch::x86_64::*;
-
     #[rustfmt::skip]
     let a = _mm_setr_epi8(
         0b1000_0000u8 as i8, 0b0, 0b1000_0000u8 as i8, 0b01,
@@ -131,17 +128,45 @@ unsafe fn test_mm_movemask_epi8() {
 
 #[target_feature(enable = "avx2")]
 unsafe fn test_mm256_movemask_epi8() {
-    use std::arch::x86_64::*;
-
     let a = _mm256_set1_epi8(-1);
     let r = _mm256_movemask_epi8(a);
     let e = -1;
     assert_eq!(r, e);
 }
 
+#[target_feature(enable = "sse2")]
+unsafe fn test_mm_add_epi8() {
+    let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    #[rustfmt::skip]
+    let b = _mm_setr_epi8(
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    );
+    let r = _mm_add_epi8(a, b);
+    #[rustfmt::skip]
+    let e = _mm_setr_epi8(
+        16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46,
+    );
+    assert_eq_m128i(r, e);
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn test_mm_add_pd() {
+    let a = _mm_setr_pd(1.0, 2.0);
+    let b = _mm_setr_pd(5.0, 10.0);
+    let r = _mm_add_pd(a, b);
+    assert_eq_m128d(r, _mm_setr_pd(6.0, 12.0));
+}
+
 fn assert_eq_m128i(x: std::arch::x86_64::__m128i, y: std::arch::x86_64::__m128i) {
     unsafe {
         assert_eq!(std::mem::transmute::<_, [u8; 16]>(x), std::mem::transmute::<_, [u8; 16]>(x));
+    }
+}
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn assert_eq_m128d(a: __m128d, b: __m128d) {
+    if _mm_movemask_pd(_mm_cmpeq_pd(a, b)) != 0b11 {
+        panic!("{:?} != {:?}", a, b);
     }
 }
 

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 use std::intrinsics;
 
+
 fn main() {
     let _ = ::std::iter::repeat('a' as u8).take(10).collect::<Vec<_>>();
     let stderr = ::std::io::stderr();
@@ -43,6 +44,21 @@ fn main() {
     assert_eq!(0xFEDCBA987654321123456789ABCDEFu128 >> 64, 0xFEDCBA98765432u128);
     assert_eq!(0xFEDCBA987654321123456789ABCDEFu128 as i128 >> 64, 0xFEDCBA98765432i128);
     assert_eq!(353985398u128 * 932490u128, 330087843781020u128);
+
+    unsafe {
+        test_simd();
+    }
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn test_simd() {
+    use std::arch::x86_64::*;
+
+    let x = _mm_setzero_si128();
+    let y = _mm_set1_epi16(7);
+    let or = _mm_or_si128(x, y);
+
+    assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 7]);
 }
 
 #[derive(PartialEq)]

--- a/example/std_example.rs
+++ b/example/std_example.rs
@@ -59,12 +59,60 @@ unsafe fn test_simd() {
     let or = _mm_or_si128(x, y);
     let cmp_eq = _mm_cmpeq_epi8(y, y);
     let cmp_lt = _mm_cmplt_epi8(y, y);
-    let shl = _mm_slli_si128(y, 1);
 
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 7]);
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_eq), [0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff]);
     assert_eq!(std::mem::transmute::<_, [u16; 8]>(cmp_lt), [0, 0, 0, 0, 0, 0, 0, 0]);
-    assert_eq!(std::mem::transmute::<_, [u16; 8]>(or), [7, 7, 7, 7, 7, 7, 7, 0]);
+
+    test_mm_slli_si128();
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn test_mm_slli_si128() {
+    use std::arch::x86_64::*;
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    );
+    let r = _mm_slli_si128(a, 1);
+    let e = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    assert_eq_m128i(r, e);
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    );
+    let r = _mm_slli_si128(a, 15);
+    let e = _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+    assert_eq_m128i(r, e);
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    );
+    let r = _mm_slli_si128(a, 16);
+    assert_eq_m128i(r, _mm_set1_epi8(0));
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    );
+    let r = _mm_slli_si128(a, -1);
+    assert_eq_m128i(_mm_set1_epi8(0), r);
+
+    #[rustfmt::skip]
+    let a = _mm_setr_epi8(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    );
+    let r = _mm_slli_si128(a, -0x80000000);
+    assert_eq_m128i(r, _mm_set1_epi8(0));
+}
+
+fn assert_eq_m128i(x: std::arch::x86_64::__m128i, y: std::arch::x86_64::__m128i) {
+    unsafe {
+        assert_eq!(std::mem::transmute::<_, [u8; 16]>(x), std::mem::transmute::<_, [u8; 16]>(x));
+    }
 }
 
 #[derive(PartialEq)]

--- a/patches/0015-Remove-usage-of-unsized-locals.patch
+++ b/patches/0015-Remove-usage-of-unsized-locals.patch
@@ -94,5 +94,18 @@ index b2142e7..718bb1c 100644
  }
  
  pub fn min_stack() -> usize {
+diff --git a/src/libstd/sys/unix/thread.rs b/src/libstd/sys/unix/thread.rs
+index f4a1783..362b537 100644
+--- a/src/libstd/sys/unix/thread.rs
++++ b/src/libstd/sys/unix/thread.rs
+@@ -40,6 +40,8 @@ impl Thread {
+     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
+     pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>)
+                           -> io::Result<Thread> {
++        panic!("Threads are not yet supported, because cranelift doesn't support atomics.");
++
+         let p = box p;
+         let mut native: libc::pthread_t = mem::zeroed();
+         let mut attr: libc::pthread_attr_t = mem::zeroed();
 -- 
 2.20.1 (Apple Git-117)

--- a/patches/0016-Disable-cpuid-intrinsic.patch
+++ b/patches/0016-Disable-cpuid-intrinsic.patch
@@ -1,0 +1,25 @@
+From 7403e2998345ef0650fd50628d7098d4d1e88e5c Mon Sep 17 00:00:00 2001
+From: bjorn3 <bjorn3@users.noreply.github.com>
+Date: Sat, 6 Apr 2019 12:16:21 +0200
+Subject: [PATCH] Remove usage of unsized locals
+
+---
+ src/stdarch/crates/core_arch/src/x86/cpuid.rs | 2 ++
+ 1 files changed, 2 insertions(+), 0 deletions(-)
+
+diff --git a/src/stdarch/crates/core_arch/src/x86/cpuid.rs b/src/stdarch/crates/core_arch/src/x86/cpuid.rs
+index f313c42..ff952bc 100644
+--- a/src/stdarch/crates/core_arch/src/x86/cpuid.rs
++++ b/src/stdarch/crates/core_arch/src/x86/cpuid.rs
+@@ -84,6 +84,9 @@ pub unsafe fn __cpuid(leaf: u32) -> CpuidResult {
+ /// Does the host support the `cpuid` instruction?
+ #[inline]
+ pub fn has_cpuid() -> bool {
++    // __cpuid intrinsic is not yet implemented
++    return false;
++
+     #[cfg(target_env = "sgx")]
+     {
+         false
+-- 
+2.20.1 (Apple Git-117)

--- a/prepare.sh
+++ b/prepare.sh
@@ -4,3 +4,10 @@ set -e
 rustup component add rust-src
 ./build_sysroot/prepare_sysroot_src.sh
 cargo install hyperfine || echo "Skipping hyperfine install"
+
+git clone https://github.com/rust-lang/regex.git || echo "rust-lang/regex has already been cloned"
+pushd regex
+git checkout -- .
+git checkout 341f207c1071f7290e3f228c710817c280c8dca1
+git apply ../crate_patches/regex.patch
+popd

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -643,6 +643,11 @@ pub fn codegen_terminator_call<'a, 'tcx: 'a>(
         let instance =
             ty::Instance::resolve(fx.tcx, ty::ParamEnv::reveal_all(), def_id, substs).unwrap();
 
+        if fx.tcx.symbol_name(instance).as_str().starts_with("llvm.") {
+            crate::llvm_intrinsics::codegen_llvm_intrinsic_call(fx, &fx.tcx.symbol_name(instance).as_str(), substs, args, destination);
+            return;
+        }
+
         match instance.def {
             InstanceDef::Intrinsic(_) => {
                 crate::intrinsics::codegen_intrinsic_call(fx, def_id, substs, args, destination);

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -274,7 +274,9 @@ impl<'a, 'tcx: 'a, B: Backend + 'a> FunctionCx<'a, 'tcx, B> {
             .module
             .declare_func_in_func(func_id, &mut self.bcx.func);
         let call_inst = self.bcx.ins().call(func_ref, args);
-        self.add_comment(call_inst, format!("easy_call {}", name));
+        #[cfg(debug_assertions)] {
+            self.add_comment(call_inst, format!("easy_call {}", name));
+        }
         let results = self.bcx.inst_results(call_inst);
         assert!(results.len() <= 2, "{}", results.len());
         results

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -877,10 +877,15 @@ pub fn codegen_intrinsic_call<'a, 'tcx: 'a>(
                 assert!(idx < total_len, "idx {} out of range 0..{}", idx, total_len);
             }
 
-
-
-            println!("{:?}", indexes);
-            unimplemented!();
+            for (out_idx, in_idx) in indexes.into_iter().enumerate() {
+                let in_lane = if in_idx < lane_count {
+                    x.value_field(fx, mir::Field::new(in_idx.try_into().unwrap()))
+                } else {
+                    y.value_field(fx, mir::Field::new((in_idx - lane_count).try_into().unwrap()))
+                };
+                let out_lane = ret.place_field(fx, mir::Field::new(out_idx));
+                out_lane.write_cvalue(fx, in_lane);
+            }
         };
 
         simd_add, (c x, c y) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod debuginfo;
 mod driver;
 mod intrinsics;
 mod linkage;
+mod llvm_intrinsics;
 mod main_shim;
 mod metadata;
 mod pretty_clif;

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -9,8 +9,50 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
     args: &[mir::Operand<'tcx>],
     destination: Option<(CPlace<'tcx>, BasicBlock)>,
 ) {
-    fx.tcx.sess.warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
-    crate::trap::trap_unimplemented(fx, intrinsic);
+    let ret = match destination {
+        Some((place, _)) => place,
+        None => {
+            // Insert non returning intrinsics here
+            match intrinsic {
+                "abort" => {
+                    trap_panic(fx, "Called intrinsic::abort.");
+                }
+                "unreachable" => {
+                    trap_unreachable(fx, "[corruption] Called intrinsic::unreachable.");
+                }
+                _ => unimplemented!("unsupported instrinsic {}", intrinsic),
+            }
+            return;
+        }
+    };
+
+    crate::intrinsics::intrinsic_match! {
+        fx, intrinsic, substs, args,
+        _ => {
+            fx.tcx.sess.warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
+            crate::trap::trap_unimplemented(fx, intrinsic);
+        };
+
+        // Used by _mm_movemask_epi8
+        llvm.x86.sse2.pmovmskb.128, (c a) {
+            let (lane_layout, lane_count) = crate::intrinsics::lane_type_and_count(fx, a.layout(), intrinsic);
+            assert_eq!(lane_layout.ty.sty, fx.tcx.types.i8.sty);
+            assert_eq!(lane_count, 16);
+
+            let mut res = fx.bcx.ins().iconst(types::I32, 0);
+
+            for lane in 0..16 {
+                let a_lane = a.value_field(fx, mir::Field::new(lane.try_into().unwrap())).load_scalar(fx);
+                let a_lane_sign = fx.bcx.ins().ushr_imm(a_lane, 7); // extract sign bit of 8bit int
+                let a_lane_sign = fx.bcx.ins().uextend(types::I32, a_lane_sign);
+                res = fx.bcx.ins().ishl_imm(res, 1);
+                res = fx.bcx.ins().bor(res, a_lane_sign);
+            }
+
+            let res = CValue::by_val(res, fx.layout_of(fx.tcx.types.i32));
+            ret.write_cvalue(fx, res);
+        };
+    }
 
     if let Some((_, dest)) = destination {
         let ret_ebb = fx.get_ebb(dest);
@@ -20,7 +62,6 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
     }
 }
 
-// llvm.x86.sse2.pmovmskb.128
 // llvm.x86.avx2.vperm2i128
 // llvm.x86.ssse3.pshuf.b.128
 // llvm.x86.avx2.pshuf.b

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -41,7 +41,7 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
 
             let mut res = fx.bcx.ins().iconst(types::I32, 0);
 
-            for lane in 0..lane_count {
+            for lane in (0..lane_count).rev() {
                 let a_lane = a.value_field(fx, mir::Field::new(lane.try_into().unwrap())).load_scalar(fx);
                 let a_lane_sign = fx.bcx.ins().ushr_imm(a_lane, 7); // extract sign bit of 8bit int
                 let a_lane_sign = fx.bcx.ins().uextend(types::I32, a_lane_sign);

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -19,3 +19,11 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
         trap_unreachable(fx, "[corruption] Diverging intrinsic returned.");
     }
 }
+
+// llvm.x86.sse2.pmovmskb.128
+// llvm.x86.avx2.vperm2i128
+// llvm.x86.ssse3.pshuf.b.128
+// llvm.x86.avx2.pshuf.b
+// llvm.x86.avx2.pmovmskb
+// llvm.x86.avx2.psrli.w
+// llvm.x86.sse2.psrli.w

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+use rustc::ty::subst::SubstsRef;
+
+pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
+    fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+    intrinsic: &str,
+    substs: SubstsRef<'tcx>,
+    args: Vec<CValue<'tcx>>,
+    destination: Option<(CPlace<'tcx>, BasicBlock)>,
+) {
+    fx.tcx.sess.warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
+    crate::trap::trap_unimplemented(fx, intrinsic);
+
+    if let Some((_, dest)) = destination {
+        let ret_ebb = fx.get_ebb(dest);
+        fx.bcx.ins().jump(ret_ebb, &[]);
+    } else {
+        trap_unreachable(fx, "[corruption] Diverging intrinsic returned.");
+    }
+}

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -6,7 +6,7 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
     fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
     intrinsic: &str,
     substs: SubstsRef<'tcx>,
-    args: Vec<CValue<'tcx>>,
+    args: &[mir::Operand<'tcx>],
     destination: Option<(CPlace<'tcx>, BasicBlock)>,
 ) {
     fx.tcx.sess.warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));

--- a/src/llvm_intrinsics.rs
+++ b/src/llvm_intrinsics.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::intrinsics::*;
 
 use rustc::ty::subst::SubstsRef;
 
@@ -26,7 +27,7 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
         }
     };
 
-    crate::intrinsics::intrinsic_match! {
+    intrinsic_match! {
         fx, intrinsic, substs, args,
         _ => {
             fx.tcx.sess.warn(&format!("unsupported llvm intrinsic {}; replacing with trap", intrinsic));
@@ -34,23 +35,64 @@ pub fn codegen_llvm_intrinsic_call<'a, 'tcx: 'a>(
         };
 
         // Used by `_mm_movemask_epi8` and `_mm256_movemask_epi8`
-        llvm.x86.sse2.pmovmskb.128 | llvm.x86.avx2.pmovmskb, (c a) {
-            let (lane_layout, lane_count) = crate::intrinsics::lane_type_and_count(fx, a.layout(), intrinsic);
-            assert_eq!(lane_layout.ty.sty, fx.tcx.types.i8.sty);
-            assert!(lane_count == 16 || lane_count == 32);
+        llvm.x86.sse2.pmovmskb.128 | llvm.x86.avx2.pmovmskb | llvm.x86.sse2.movmsk.pd, (c a) {
+            let (lane_layout, lane_count) = lane_type_and_count(fx, a.layout(), intrinsic);
+            let lane_ty = fx.clif_type(lane_layout.ty).unwrap();
+            assert!(lane_count <= 32);
 
             let mut res = fx.bcx.ins().iconst(types::I32, 0);
 
             for lane in (0..lane_count).rev() {
                 let a_lane = a.value_field(fx, mir::Field::new(lane.try_into().unwrap())).load_scalar(fx);
-                let a_lane_sign = fx.bcx.ins().ushr_imm(a_lane, 7); // extract sign bit of 8bit int
-                let a_lane_sign = fx.bcx.ins().uextend(types::I32, a_lane_sign);
+
+                // cast float to int
+                let a_lane = match lane_ty {
+                    types::F32 => fx.bcx.ins().bitcast(types::I32, a_lane),
+                    types::F64 => fx.bcx.ins().bitcast(types::I64, a_lane),
+                    _ => a_lane,
+                };
+
+                // extract sign bit of an int
+                let a_lane_sign = fx.bcx.ins().ushr_imm(a_lane, i64::from(lane_ty.bits() - 1));
+
+                // shift sign bit into result
+                let a_lane_sign = clif_intcast(fx, a_lane_sign, types::I32, false);
                 res = fx.bcx.ins().ishl_imm(res, 1);
                 res = fx.bcx.ins().bor(res, a_lane_sign);
             }
 
             let res = CValue::by_val(res, fx.layout_of(fx.tcx.types.i32));
             ret.write_cvalue(fx, res);
+        };
+        llvm.x86.sse2.cmp.ps | llvm.x86.sse2.cmp.pd, (c x, c y, o kind) {
+            let kind_const = crate::constant::mir_operand_get_const_val(fx, kind).expect("llvm.x86.sse2.cmp.* kind not const");
+            let flt_cc = match kind_const.val.try_to_bits(Size::from_bytes(1)).expect(&format!("kind not scalar: {:?}", kind_const)) {
+                0 => FloatCC::Equal,
+                1 => FloatCC::LessThan,
+                2 => FloatCC::LessThanOrEqual,
+                7 => {
+                    unimplemented!("Compares corresponding elements in `a` and `b` to see if neither is `NaN`.");
+                }
+                3 => {
+                    unimplemented!("Compares corresponding elements in `a` and `b` to see if either is `NaN`.");
+                }
+                4 => FloatCC::NotEqual,
+                5 => {
+                    unimplemented!("not less than");
+                }
+                6 => {
+                    unimplemented!("not less than or equal");
+                }
+                kind => unreachable!("kind {:?}", kind),
+            };
+
+            simd_for_each_lane(fx, intrinsic, x, y, ret, |fx, lane_layout, res_lane_layout, x_lane, y_lane| {
+                let res_lane = match lane_layout.ty.sty {
+                    ty::Float(_) => fx.bcx.ins().fcmp(flt_cc, x_lane, y_lane),
+                    _ => unreachable!("{:?}", lane_layout.ty),
+                };
+                bool_to_zero_or_max_uint(fx, res_lane_layout, res_lane)
+            });
         };
     }
 

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -7,7 +7,9 @@ fn codegen_print(fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>, ms
         returns: vec![],
     }).unwrap();
     let puts = fx.module.declare_func_in_func(puts, &mut fx.bcx.func);
-    fx.add_entity_comment(puts, "puts");
+    #[cfg(debug_assertions)] {
+        fx.add_entity_comment(puts, "puts");
+    }
 
     let symbol_name = fx.tcx.symbol_name(fx.instance);
     let real_msg = format!("trap at {:?} ({}): {}\0", fx.instance, symbol_name, msg);
@@ -19,7 +21,9 @@ fn codegen_print(fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>, ms
     let _ = fx.module.define_data(msg_id, &data_ctx);
 
     let local_msg_id = fx.module.declare_data_in_func(msg_id, fx.bcx.func);
-    fx.add_entity_comment(local_msg_id, msg);
+    #[cfg(debug_assertions)] {
+        fx.add_entity_comment(local_msg_id, msg);
+    }
     let msg_ptr = fx.bcx.ins().global_value(pointer_ty(fx.tcx), local_msg_id);
     fx.bcx.ins().call(puts, &[msg_ptr]);
 }

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ "$1" == "--release" ]]; then
     export CHANNEL='release'
     cargo build --release


### PR DESCRIPTION
This makes it possible to compile for example `rust-lang/regex`.

There are still many intrinsics being unsupported. This also doesn't use cpu simd instructions.

cc #171
cc @gnzlbg, as you opened the above issue