### PR TITLE
Load dependent dylibs in JIT mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,15 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libloading"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +615,7 @@ dependencies = [
  "gimli 0.19.0 (git+https://github.com/gimli-rs/gimli.git)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "object 0.12.0 (git+https://github.com/gimli-rs/object.git)",
  "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -884,6 +894,7 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
+"checksum libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5692f82b51823e27c4118b3e5c0d98aee9be90633ebc71ad12afef380b50219"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempfile = "3.0.7"
 gimli = { git = "https://github.com/gimli-rs/gimli.git" }
 indexmap = "1.0.2"
 object = "0.12.0"
+libloading = "0.5.1"
 
 [patch."https://github.com/CraneStation/cranelift.git"]
 cranelift = { git = "https://github.com/bjorn3/cretonne.git", branch = "do_not_remove_cg_clif_i128" }

--- a/build_sysroot/build_sysroot.sh
+++ b/build_sysroot/build_sysroot.sh
@@ -28,7 +28,7 @@ fi
 
 # Copy files to sysroot
 mkdir -p sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
-cp target/$TARGET_TRIPLE/$sysroot_channel/deps/*.rlib sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
+cp target/$TARGET_TRIPLE/$sysroot_channel/deps/* sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
 
 if [[ "$1" == "--release" ]]; then
     channel='release'
@@ -39,4 +39,4 @@ else
 fi
 
 # Copy files to sysroot
-cp sysroot_src/src/libtest/target/$TARGET_TRIPLE/$sysroot_channel/deps/*.rlib sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
+cp sysroot_src/src/libtest/target/$TARGET_TRIPLE/$sysroot_channel/deps/*  sysroot/lib/rustlib/$TARGET_TRIPLE/lib/

--- a/config.sh
+++ b/config.sh
@@ -15,3 +15,6 @@ TARGET_TRIPLE=$(rustc -vV | grep host | cut -d: -f2 | tr -d " ")
 export RUSTFLAGS='-Zalways-encode-mir -Cpanic=abort -Cdebuginfo=2 -Zcodegen-backend='$(pwd)'/target/'$CHANNEL'/librustc_codegen_cranelift.'$dylib_ext' --sysroot '$(pwd)'/build_sysroot/sysroot'
 RUSTC="rustc $RUSTFLAGS -L crate=target/out --out-dir target/out"
 export RUSTC_LOG=warn # display metadata load errors
+
+export LD_LIBRARY_PATH=$(pwd)/target/out
+export DYLD_LIBRARY_PATH=$(pwd)/target/out

--- a/config.sh
+++ b/config.sh
@@ -16,5 +16,5 @@ export RUSTFLAGS='-Zalways-encode-mir -Cpanic=abort -Cdebuginfo=2 -Zcodegen-back
 RUSTC="rustc $RUSTFLAGS -L crate=target/out --out-dir target/out"
 export RUSTC_LOG=warn # display metadata load errors
 
-export LD_LIBRARY_PATH=$(pwd)/target/out
-export DYLD_LIBRARY_PATH=$(pwd)/target/out
+export LD_LIBRARY_PATH="$(pwd)/target/out:$(pwd)/build_sysroot/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
+export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH

--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -369,9 +369,6 @@ pub trait FnMut<Args>: FnOnce<Args> {
 }
 
 #[lang = "panic"]
-// Make it available to jited mini_core_hello_world
-// FIXME remove next line when jit supports linking rlibs
-#[inline(always)]
 pub fn panic(&(_msg, _file, _line, _col): &(&'static str, &'static str, u32, u32)) -> ! {
     unsafe {
         libc::puts("Panicking\0" as *const str as *const u8);
@@ -419,15 +416,11 @@ impl<T> Deref for Box<T> {
 }
 
 #[lang = "exchange_malloc"]
-// Make it available to jited mini_core_hello_world
-// FIXME remove next line when jit supports linking rlibs
-#[inline(always)]
 unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
     libc::malloc(size)
 }
 
 #[lang = "box_free"]
-#[inline(always)]
 unsafe fn box_free<T: ?Sized>(ptr: *mut T) {
     libc::free(ptr as *mut u8);
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -18,13 +18,6 @@ pub fn codegen_crate(
     metadata: EncodedMetadata,
     need_metadata_module: bool,
 ) -> Box<dyn Any> {
-    if !tcx.sess.crate_types.get().contains(&CrateType::Executable)
-        && std::env::var("SHOULD_RUN").is_ok()
-    {
-        tcx.sess
-            .err("Can't JIT run non executable (SHOULD_RUN env var is set)");
-    }
-
     tcx.sess.abort_if_errors();
 
     let mut log = if cfg!(debug_assertions) {
@@ -33,7 +26,9 @@ pub fn codegen_crate(
         None
     };
 
-    if std::env::var("SHOULD_RUN").is_ok() {
+    if std::env::var("SHOULD_RUN").is_ok()
+        && tcx.sess.crate_types.get().contains(&CrateType::Executable)
+    {
         #[cfg(not(target_arch = "wasm32"))]
         let _: ! = run_jit(tcx, &mut log);
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -79,7 +79,6 @@ fn run_jit(tcx: TyCtxt<'_>, log: &mut Option<File>) -> ! {
             if name.is_empty() || !symbol.is_global() || symbol.is_undefined() {
                 return None;
             }
-            println!("name: {:?}", name);
             let symbol: libloading::Symbol<*const u8> =
                 unsafe { lib.get(name.as_bytes()) }.unwrap();
             Some((name, *symbol))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,10 +239,14 @@ fn target_triple(sess: &Session) -> target_lexicon::Triple {
     target.parse().unwrap()
 }
 
-fn build_isa(sess: &Session) -> Box<dyn isa::TargetIsa + 'static> {
+fn build_isa(sess: &Session, enable_pic: bool) -> Box<dyn isa::TargetIsa + 'static> {
     let mut flags_builder = settings::builder();
-    flags_builder.enable("is_pic").unwrap();
-    flags_builder.set("probestack_enabled", "false").unwrap(); // ___cranelift_probestack is not provided
+    if enable_pic {
+        flags_builder.enable("is_pic").unwrap();
+    } else {
+        flags_builder.set("is_pic", "false").unwrap();
+    }
+    flags_builder.set("probestack_enabled", "false").unwrap(); // __cranelift_probestack is not provided
         flags_builder.set("enable_verifier", if cfg!(debug_assertions) {
         "true"
     } else {

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -218,7 +218,7 @@ pub fn write_clif_file<'tcx>(
         &mut clif,
         &func,
         &DisplayFunctionAnnotations {
-            isa: Some(&*crate::build_isa(tcx.sess)),
+            isa: Some(&*crate::build_isa(tcx.sess, true /* PIC doesn't matter here */)),
             value_ranges,
         },
     )

--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ $RUSTC example/arbitrary_self_types_pointers_and_wrappers.rs --crate-name arbitr
 ./target/out/arbitrary_self_types_pointers_and_wrappers
 
 echo "[BUILD] sysroot"
-#time ./build_sysroot/build_sysroot.sh
+time ./build_sysroot/build_sysroot.sh
 
 echo "[AOT] alloc_example"
 $RUSTC example/alloc_example.rs --crate-type bin

--- a/test.sh
+++ b/test.sh
@@ -33,13 +33,16 @@ $RUSTC example/arbitrary_self_types_pointers_and_wrappers.rs --crate-name arbitr
 ./target/out/arbitrary_self_types_pointers_and_wrappers
 
 echo "[BUILD] sysroot"
-time ./build_sysroot/build_sysroot.sh
+#time ./build_sysroot/build_sysroot.sh
 
-echo "[BUILD+RUN] alloc_example"
+echo "[AOT] alloc_example"
 $RUSTC example/alloc_example.rs --crate-type bin
 ./target/out/alloc_example
 
-echo "[BUILD+RUN] std_example"
+echo "[JIT] std_example"
+SHOULD_RUN=1 $RUSTC example/std_example.rs --crate-type bin -Cprefer-dynamic
+
+echo "[AOT] std_example"
 $RUSTC example/std_example.rs --crate-type bin
 ./target/out/std_example
 


### PR DESCRIPTION
This makes the JIT mode more than just a toy. Using `cargo run` is not yet supported though.

Fixes #167