### PR TITLE
Use upstream cranelift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cranelift"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-frontend 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
 ]
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-bforest 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-codegen-meta 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
@@ -95,13 +95,14 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
 ]
@@ -109,12 +110,12 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 
 [[package]]
 name = "cranelift-faerie"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
@@ -127,17 +128,18 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-module"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
@@ -148,7 +150,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -158,7 +160,7 @@ dependencies = [
 [[package]]
 name = "cranelift-simplejit"
 version = "0.42.0"
-source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
+source = "git+https://github.com/CraneStation/cranelift.git#302bcf3fbbf61bb404d8cfc206fd8e6d776bf126"
 dependencies = [
  "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
@@ -563,6 +565,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,104 +69,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cranelift"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-frontend 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-frontend 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-entity 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-bforest 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-codegen-meta 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-entity 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-bforest 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-codegen-meta 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-entity 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-module 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "faerie 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-entity 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-simplejit"
-version = "0.36.0"
-source = "git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128#e1f9de3c2b631933e79419bd5626c3f49abaebe1"
+version = "0.42.0"
+source = "git+https://github.com/CraneStation/cranelift.git#08475219ca1aa1d23c80e89534f35fbc99fbe0d7"
 dependencies = [
- "cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-module 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-native 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
+ "cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-native 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "region 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -199,16 +199,16 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string-interner 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -286,17 +286,7 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "goblin"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -498,17 +488,17 @@ dependencies = [
  "ar 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-faerie 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-module 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "cranelift-simplejit 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)",
- "faerie 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-faerie 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "cranelift-simplejit 0.42.0 (git+https://github.com/CraneStation/cranelift.git)",
+ "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.19.0 (git+https://github.com/gimli-rs/gimli.git)",
  "indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "object 0.12.0 (git+https://github.com/gimli-rs/object.git)",
- "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -579,7 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "string-interner"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,6 +599,16 @@ dependencies = [
 [[package]]
 name = "target-lexicon"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -674,20 +674,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum cranelift 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-bforest 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-codegen 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-codegen-meta 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-entity 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-faerie 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-frontend 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-module 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-native 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
-"checksum cranelift-simplejit 0.36.0 (git+https://github.com/bjorn3/cretonne.git?branch=do_not_remove_cg_clif_i128)" = "<none>"
+"checksum cranelift 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-bforest 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-codegen 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-codegen-meta 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-entity 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-faerie 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-frontend 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-module 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-native 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
+"checksum cranelift-simplejit 0.42.0 (git+https://github.com/CraneStation/cranelift.git)" = "<none>"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-"checksum faerie 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2467155f3071b96447d53af110805cadbe9162f5be6c300792fb76c0e54051"
+"checksum faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "875d78b92b2a4d9e1e2c7eeccfa30a327d2ee6434db3beb8fd6fd92f41898bc4"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
@@ -696,8 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 "checksum gimli 0.19.0 (git+https://github.com/gimli-rs/gimli.git)" = "<none>"
 "checksum goblin 0.0.22 (git+https://github.com/m4b/goblin?rev=e57f2d4e3a089dca89c63bcfc0dbde3e6d647f83)" = "<none>"
-"checksum goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"
-"checksum goblin 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "ac56b4753b6b8c2e052ca30717e5a09acf1b02a2c1681bf3d883bd660e5d22bd"
+"checksum goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e3fa261d919c1ae9d1e4533c4a2f99e10938603c4208d56c05bec7a872b661b0"
 "checksum indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4d6d89e0948bf10c08b9ecc8ac5b83f07f857ebe2c0cbe38de15b4e4f510356"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -732,10 +731,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum string-interner 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abb38a0d8fe673c40b10b6b75abcb076a958cc10fb894f14993d9737c4c87000"
+"checksum string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0ab4982b8945c35cc1c46a83a9094c414f6828a099ce5dcaa8ee2b04642dcb"
+"checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["dylib"]
 cranelift = { git = "https://github.com/CraneStation/cranelift.git" }
 cranelift-module = { git = "https://github.com/CraneStation/cranelift.git" }
 cranelift-faerie = { git = "https://github.com/CraneStation/cranelift.git" }
-target-lexicon = "0.4.0"
-faerie = "0.10.2"
+target-lexicon = "0.8.1"
+faerie = "0.11.0"
 
 #goblin = "0.0.17"
 ar = "0.8.0"
@@ -27,12 +27,6 @@ gimli = { git = "https://github.com/gimli-rs/gimli.git" }
 indexmap = "1.0.2"
 object = "0.12.0"
 libloading = "0.5.1"
-
-[patch."https://github.com/CraneStation/cranelift.git"]
-cranelift = { git = "https://github.com/bjorn3/cretonne.git", branch = "do_not_remove_cg_clif_i128" }
-cranelift-module = { git = "https://github.com/bjorn3/cretonne.git", branch = "do_not_remove_cg_clif_i128" }
-cranelift-simplejit = { git = "https://github.com/bjorn3/cretonne.git", branch = "do_not_remove_cg_clif_i128" }
-cranelift-faerie = { git = "https://github.com/bjorn3/cretonne.git", branch = "do_not_remove_cg_clif_i128" }
 
 # Uncomment to use local checkout of cranelift
 #[patch."https://github.com/CraneStation/cranelift.git"]

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -73,10 +73,8 @@ pub fn codegen_inner(module: &mut Module<impl Backend + 'static>, kind: Allocato
             .unwrap();
 
         let mut ctx = Context::new();
-        ctx.func = Function::with_name_signature(ExternalName::user(0, 0), sig.clone());
-        {
-            let mut func_ctx = FunctionBuilderContext::new();
-            let mut bcx = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+        ctx.func = {
+            let mut bcx = FunctionBuilder::new(Function::with_name_signature(ExternalName::user(0, 0), sig.clone()));
 
             let ebb = bcx.create_ebb();
             bcx.switch_to_block(ebb);
@@ -92,8 +90,9 @@ pub fn codegen_inner(module: &mut Module<impl Backend + 'static>, kind: Allocato
             let results = bcx.inst_results(call_inst).to_vec(); // Clone to prevent borrow error
             bcx.ins().return_(&results);
             bcx.seal_all_blocks();
-            bcx.finalize();
-        }
+            bcx.finalize()
+        };
+
         module.define_function(func_id, &mut ctx).unwrap();
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -19,10 +19,8 @@ pub fn trans_fn<'clif, 'tcx, B: Backend + 'static>(
         .as_mut()
         .map(|debug_context| FunctionDebugContext::new(tcx, debug_context, mir, &name, &sig));
 
-    // Make FunctionBuilder
-    let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
-    let mut func_ctx = FunctionBuilderContext::new();
-    let mut bcx = FunctionBuilder::new(&mut func, &mut func_ctx);
+    // FIXME reuse Function and FunctionBuilder between multiple trans_fn calls
+    let mut bcx = FunctionBuilder::new(Function::with_name_signature(ExternalName::user(0, 0), sig));
 
     // Predefine ebb's
     let start_ebb = bcx.create_ebb();
@@ -57,6 +55,9 @@ pub fn trans_fn<'clif, 'tcx, B: Backend + 'static>(
         crate::abi::codegen_fn_prelude(&mut fx, start_ebb);
         codegen_fn_content(&mut fx);
     });
+
+    fx.bcx.seal_all_blocks();
+    let func = fx.bcx.finalize();
 
     // Recover all necessary data from fx, before accessing func will prevent future access to it.
     let instance = fx.instance;
@@ -238,9 +239,6 @@ fn codegen_fn_content(fx: &mut FunctionCx<'_, '_, impl Backend>) {
             }
         };
     }
-
-    fx.bcx.seal_all_blocks();
-    fx.bcx.finalize();
 }
 
 fn trans_stmt<'tcx>(

--- a/src/codegen_i128.rs
+++ b/src/codegen_i128.rs
@@ -98,7 +98,7 @@ pub fn maybe_codegen<'tcx>(
             // Optimize `val >> 64`, because compiler_builtins uses it to deconstruct an 128bit
             // integer into its lsb and msb.
             // https://github.com/rust-lang-nursery/compiler-builtins/blob/79a6a1603d5672cbb9187ff41ff4d9b5048ac1cb/src/int/mod.rs#L217
-            if let Some(64) = resolve_value_imm(fx.bcx.func, rhs_val) {
+            if let Some(64) = resolve_value_imm(&fx.bcx.func, rhs_val) {
                 let (lhs_lsb, lhs_msb) = fx.bcx.ins().isplit(lhs_val);
                 let all_zeros = fx.bcx.ins().iconst(types::I64, 0);
                 let val = match (bin_op, is_signed) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -269,7 +269,7 @@ pub struct FunctionCx<'clif, 'tcx, B: Backend + 'static> {
     pub instance: Instance<'tcx>,
     pub mir: &'tcx Body<'tcx>,
 
-    pub bcx: FunctionBuilder<'clif>,
+    pub bcx: FunctionBuilder,
     pub ebb_map: HashMap<BasicBlock, Ebb>,
     pub local_map: HashMap<Local, CPlace<'tcx>>,
 

--- a/src/main_shim.rs
+++ b/src/main_shim.rs
@@ -56,10 +56,10 @@ pub fn maybe_create_entry_wrapper(tcx: TyCtxt<'_>, module: &mut Module<impl Back
             .unwrap();
 
         let mut ctx = Context::new();
-        ctx.func = Function::with_name_signature(ExternalName::user(0, 0), cmain_sig.clone());
-        {
-            let mut func_ctx = FunctionBuilderContext::new();
-            let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+        ctx.func = {
+            let mut bcx: FunctionBuilder = FunctionBuilder::new(
+                Function::with_name_signature(ExternalName::user(0, 0), cmain_sig.clone())
+            );
 
             let ebb = bcx.create_ebb();
             bcx.switch_to_block(ebb);
@@ -93,8 +93,9 @@ pub fn maybe_create_entry_wrapper(tcx: TyCtxt<'_>, module: &mut Module<impl Back
             let result = bcx.inst_results(call_inst)[0];
             bcx.ins().return_(&[result]);
             bcx.seal_all_blocks();
-            bcx.finalize();
-        }
+            bcx.finalize()
+        };
+
         m.define_function(cmain_func_id, &mut ctx).unwrap();
     }
 }

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -36,7 +36,7 @@ fn codegen_print(fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>, ms
     // Ignore DuplicateDefinition error, as the data will be the same
     let _ = fx.module.define_data(msg_id, &data_ctx);
 
-    let local_msg_id = fx.module.declare_data_in_func(msg_id, fx.bcx.func);
+    let local_msg_id = fx.module.declare_data_in_func(msg_id, &mut fx.bcx.func);
     #[cfg(debug_assertions)]
     {
         fx.add_entity_comment(local_msg_id, msg);


### PR DESCRIPTION
Now that https://github.com/CraneStation/cranelift/pull/795 (I128) is merged, we can finally use upstream Cranelift again.