### PR TITLE
Fix debuginfo for machO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "git+https://github.com/CraneStation/cranelift.git#387593d6c94d291e614c
 dependencies = [
  "cranelift-codegen 0.46.1 (git+https://github.com/CraneStation/cranelift.git)",
  "cranelift-module 0.46.1 (git+https://github.com/CraneStation/cranelift.git)",
- "object 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "object 0.14.0 (git+https://github.com/gimli-rs/object.git)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "object"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gimli-rs/object.git#50391629ce0691dda4fb6ea57cf920cee80130c6"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,7 +431,7 @@ dependencies = [
  "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "object 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "object 0.14.0 (git+https://github.com/gimli-rs/object.git)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -629,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum miniz_oxide 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "304f66c19be2afa56530fa7c39796192eef38618da8d19df725ad7c6d6b2aaae"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-"checksum object 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81afbc5773e99efe9533d8a539dfac37e531dcd0f4eeb41584bae03ccf76d4c2"
+"checksum object 0.14.0 (git+https://github.com/gimli-rs/object.git)" = "<none>"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cranelift-simplejit = { git = "https://github.com/CraneStation/cranelift.git" }
 # By compiling dependencies with optimizations, performing tests gets much faster.
 opt-level = 3
 
-[profile.dev.overrides."rustc_codegen_cranelift"]
+[profile.dev.package.rustc_codegen_cranelift]
 # Disabling optimizations for cg_clif itself makes compilation after a change faster.
 opt-level = 0
 
@@ -62,14 +62,14 @@ opt-level = 0
 opt-level = 0
 debug = false
 
-[profile.dev.overrides.cranelift-codegen-meta]
+[profile.dev.package.cranelift-codegen-meta]
 opt-level = 0
 debug = false
 
-[profile.dev.overrides.syn]
+[profile.dev.package.syn]
 opt-level = 0
 debug = false
 
-[profile.dev.overrides.synstructure]
+[profile.dev.package.synstructure]
 opt-level = 0
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ features = ["compression", "read", "std"] # We don't need WASM support
 #[patch.crates-io]
 #gimli = { path = "../" }
 
+[patch.crates-io]
+# FIXME switch back to crates.io once gimli-rs/object#133 is published
+object = { git = "https://github.com/gimli-rs/object.git" }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cranelift-simplejit = { git = "https://github.com/CraneStation/cranelift.git" }
 

--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -1,6 +1,6 @@
 #![feature(
     no_core, lang_items, intrinsics, unboxed_closures, type_ascription, extern_types,
-    untagged_unions, decl_macro, rustc_attrs
+    untagged_unions, decl_macro, rustc_attrs, transparent_unions
 )]
 #![no_core]
 #![allow(dead_code)]
@@ -448,10 +448,17 @@ pub trait Drop {
     fn drop(&mut self);
 }
 
-#[allow(unions_with_drop_fields)]
+#[lang = "manually_drop"]
+#[repr(transparent)]
+pub struct ManuallyDrop<T: ?Sized> {
+    pub value: T,
+}
+
+#[lang = "maybe_uninit"]
+#[repr(transparent)]
 pub union MaybeUninit<T> {
     pub uninit: (),
-    pub value: T,
+    pub value: ManuallyDrop<T>,
 }
 
 pub mod intrinsics {

--- a/example/mini_core_hello_world.rs
+++ b/example/mini_core_hello_world.rs
@@ -196,7 +196,7 @@ fn main() {
         }
 
         unsafe fn uninitialized<T>() -> T {
-            MaybeUninit { uninit: () }.value
+            MaybeUninit { uninit: () }.value.value
         }
 
         zeroed::<(u8, u8)>();

--- a/patches/0017-Fix-libtest-compilation.patch
+++ b/patches/0017-Fix-libtest-compilation.patch
@@ -12,18 +12,18 @@ index 8b76080..9e65de2 100644
 --- a/src/libtest/lib.rs
 +++ b/src/libtest/lib.rs
 @@ -52,7 +52,7 @@ use std::fmt;
- use std::fs::File;
- use std::io;
- use std::io::prelude::*;
--use std::panic::{self, catch_unwind, AssertUnwindSafe, PanicInfo};
-+use std::panic::{self, PanicInfo};
- use std::path::PathBuf;
- use std::process;
- use std::process::{ExitStatus, Command, Termination};
+     env,
+     io,
+     io::prelude::Write,
+-    panic::{self, catch_unwind, AssertUnwindSafe, PanicInfo},
++    panic::{self, PanicInfo},
+     process,
+     process::{Command, Termination},
+     sync::mpsc::{channel, Sender},
 @@ -1493,7 +1493,7 @@ pub fn run_test(
      fn run_test_inner(
          desc: TestDesc,
-         monitor_ch: Sender<MonitorMsg>,
+         monitor_ch: Sender<CompletedTest>,
 -        testfn: Box<dyn FnOnce() + Send>,
 +        testfn: Box<impl FnOnce() + Send + 'static>,
          opts: TestRunOpts,
@@ -65,8 +65,8 @@ index 8b76080..9e65de2 100644
      report_time: bool,
 -    testfn: Box<dyn FnOnce() + Send>,
 +    testfn: Box<impl FnOnce() + Send + 'static>,
-     monitor_ch: Sender<MonitorMsg>,
-     time_opts: Option<TestTimeOptions>,
+     monitor_ch: Sender<CompletedTest>,
+     time_opts: Option<time::TestTimeOptions>,
  ) {
      // Buffer for capturing standard I/O
      let data = Arc::new(Mutex::new(Vec::new()));
@@ -75,12 +75,12 @@ index 8b76080..9e65de2 100644
          None
      };
 -    let result = catch_unwind(AssertUnwindSafe(testfn));
-+    let result = Ok::<(), Box<dyn Any + Send>>(testfn());
++    let result = Ok::<(), Box<dyn std::any::Any + Send>>(testfn());
      let exec_time = start.map(|start| {
          let duration = start.elapsed();
          TestExecTime(duration)
 @@ -1688,10 +1676,10 @@ fn spawn_test_subprocess(desc: TestDesc, report_time: bool, monitor_ch: Sender<M
-     monitor_ch.send((desc.clone(), result, exec_time, test_output)).unwrap();
+     monitor_ch.send(message).unwrap();
  }
  
  fn run_test_in_spawned_subprocess(

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash --verbose
 set -e
 
-rustup component add rust-src
+rustup component add rust-src rustc-dev
 ./build_sysroot/prepare_sysroot_src.sh
 cargo install hyperfine || echo "Skipping hyperfine install"
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -149,13 +149,7 @@ impl WriteDebugInfo for ObjectProduct {
             }
             DebugRelocName::Symbol(id) => {
                 let symbol_id = self.function_symbol(*symbol_map.get_index(id).unwrap().0);
-                let symbol = self.object.symbol(symbol_id);
-
-                // A symbol gets a section assigned when `add_symbol_data` is called.
-                let section = symbol.section.expect("Symbol not defined");
-                let symbol_offset = symbol.value;
-
-                (self.object.section_symbol(section), symbol_offset)
+                self.object.symbol_section_and_offset(symbol_id).expect("Debug reloc for undef sym???")
             }
         };
         self.object.add_relocation(from.0, Relocation {

--- a/src/common.rs
+++ b/src/common.rs
@@ -286,7 +286,9 @@ pub struct FunctionCx<'clif, 'tcx, B: Backend + 'static> {
     pub clif_comments: crate::pretty_clif::CommentWriter,
     pub constants_cx: &'clif mut crate::constant::ConstantCx,
     pub caches: &'clif mut Caches<'tcx>,
-    pub source_info_set: indexmap::IndexSet<SourceInfo>,
+
+    // FIXME switch back to `SourceInfo`, once it derives `Eq` and `Hash` again.
+    pub source_info_set: indexmap::IndexSet<(Span, mir::SourceScope)>,
 }
 
 impl<'tcx, B: Backend> LayoutOf for FunctionCx<'_, 'tcx, B> {
@@ -365,7 +367,7 @@ impl<'tcx, B: Backend + 'static> FunctionCx<'_, 'tcx, B> {
     }
 
     pub fn set_debug_loc(&mut self, source_info: mir::SourceInfo) {
-        let (index, _) = self.source_info_set.insert_full(source_info);
+        let (index, _) = self.source_info_set.insert_full((source_info.span, source_info.scope));
         self.bcx.set_srcloc(SourceLoc::new(index as u32));
     }
 }

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -252,7 +252,7 @@ impl<'a, 'tcx> FunctionDebugContext<'a, 'tcx> {
         tcx: TyCtxt,
         context: &Context,
         isa: &dyn cranelift::codegen::isa::TargetIsa,
-        source_info_set: &indexmap::IndexSet<SourceInfo>,
+        source_info_set: &indexmap::IndexSet<(Span, mir::SourceScope)>,
     ) {
         let line_program = &mut self.debug_context.dwarf.unit.line_program;
 
@@ -292,7 +292,7 @@ impl<'a, 'tcx> FunctionDebugContext<'a, 'tcx> {
                 line_program.row().address_offset = offset as u64;
                 if !srcloc.is_default() {
                     let source_info = *source_info_set.get_index(srcloc.bits() as usize).unwrap();
-                    create_row_for_span(line_program, source_info.span);
+                    create_row_for_span(line_program, source_info.0);
                 } else {
                     create_row_for_span(line_program, self.mir_span);
                 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -184,10 +184,7 @@ fn run_aot(
 
     let mut module = new_module("some_file".to_string());
 
-    let mut debug = if tcx.sess.opts.debuginfo != DebugInfo::None
-        // macOS debuginfo doesn't work yet (see #303)
-        && !tcx.sess.target.target.options.is_like_osx
-    {
+    let mut debug = if tcx.sess.opts.debuginfo != DebugInfo::None {
         let debug = DebugContext::new(
             tcx,
             module.target_config().pointer_type().bytes() as u8,


### PR DESCRIPTION
This only fixes it when using object::write as backend, and not when using faerie.

There were two problems:

* object::write doesn't replace .debug_info with __debug_info, unlike faerie
* machO requires section relative relocations, and not symbol relative
  relocations. When using symbol relative relocations, the linker
  interprets the relocations as section relative. Thus writing the wrong
  values to the debug sections.

Fixes #303

cc @philipc

# TODO

* [ ] Verify that using section relative relocations doesn't break debuginfo on Linux