### PR TITLE
Store nightly snapshot in rust-toolchain file, and use it in cargo.sh

### DIFF
--- a/cargo.sh
+++ b/cargo.sh
@@ -6,9 +6,13 @@ fi
 
 pushd $(dirname "$0") >/dev/null
 source config.sh
+
+# read nightly compiler from rust-toolchain file
+TOOLCHAIN=$(cat rust-toolchain)
+
 popd >/dev/null
 
 cmd=$1
 shift
 
-cargo $cmd --target $TARGET_TRIPLE $@
+cargo +${TOOLCHAIN} $cmd --target $TARGET_TRIPLE $@

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2020-01-13


### PR DESCRIPTION
The rust-toolchain file can also store an exact nightly snapshot
(instead of just "nightly"), so we can store whatever snapshot that
rustc_codegen_cranelift is known to work with.

This also lets us add a new feature to `cargo.sh` to let it use the
exact same nightly snapshot as cg_clif.  If there's a nightly compiler
mismatch, you get a confusing error message like:

    error: couldn't load codegen backend "librustc_codegen_cranelift.so":
    "librustc_driver-681e2b4f66c73d3e.so: cannot open
    shared object file: No such file or directory"

So doing this automatically in cargo.sh is useful.

One consequence of this change is that you'll have to remember to keep `rust-toolchain` up-to-date.