### PR TITLE
Implement .eh_frame writing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["dylib"]
 
 [dependencies]
 # These have to be in sync with each other
-cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime/" }
+cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime/", features = ["unwind"] }
 cranelift-frontend = { git = "https://github.com/bytecodealliance/wasmtime/" }
 cranelift-module = { git = "https://github.com/bytecodealliance/wasmtime/" }
 cranelift-object = { git = "https://github.com/bytecodealliance/wasmtime/" }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -39,7 +39,7 @@ impl WriteMetadata for object::write::Object {
 }
 
 pub(crate) trait WriteDebugInfo {
-    type SectionId;
+    type SectionId: Copy;
 
     fn add_debug_section(&mut self, name: SectionId, data: Vec<u8>) -> Self::SectionId;
     fn add_debug_reloc(

--- a/src/debuginfo/unwind.rs
+++ b/src/debuginfo/unwind.rs
@@ -1,0 +1,31 @@
+use crate::prelude::*;
+
+use cranelift_codegen::isa::unwind::UnwindInfo;
+
+use gimli::write::Address;
+
+impl<'a, 'tcx> FunctionDebugContext<'a, 'tcx> {
+    pub(super) fn create_unwind_info(
+        &mut self,
+        context: &Context,
+        isa: &dyn cranelift_codegen::isa::TargetIsa,
+    ) {
+        let unwind_info = if let Some(unwind_info) = context.create_unwind_info(isa).unwrap() {
+            unwind_info
+        } else {
+            return;
+        };
+
+        match unwind_info {
+            UnwindInfo::SystemV(unwind_info) => {
+                self.debug_context.frame_table.add_fde(self.debug_context.cie, unwind_info.to_fde(Address::Symbol {
+                    symbol: self.symbol,
+                    addend: 0,
+                }));
+            },
+            UnwindInfo::WindowsX64(_) => {
+                // FIXME implement this
+            }
+        }
+    }
+}

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -120,7 +120,7 @@ fn module_codegen(tcx: TyCtxt<'_>, cgu_name: rustc_span::Symbol) -> ModuleCodege
     let mut debug = if tcx.sess.opts.debuginfo != DebugInfo::None {
         let debug = DebugContext::new(
             tcx,
-            module.target_config().pointer_type().bytes() as u8,
+            module.isa(),
         );
         Some(debug)
     } else {


### PR DESCRIPTION
```
thread 'main' panicked at 'explicit panic', example/std_example.rs:8:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /home/bjorn/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /home/bjorn/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at sysroot_src/src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at sysroot_src/src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at sysroot_src/src/libcore/fmt/mod.rs:1069
   5: std::io::Write::write_fmt
             at sysroot_src/src/libstd/io/mod.rs:1504
   6: std::sys_common::backtrace::_print
             at sysroot_src/src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at sysroot_src/src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at sysroot_src/src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at sysroot_src/src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at sysroot_src/src/libstd/panicking.rs:511
  11: std::panicking::begin_panic
             at sysroot_src/src/libstd/panicking.rs:438
  12: std_example::main
             at example/std_example.rs:8
  13: std::rt::lang_start::{{closure}}
             at ./build_sysroot/sysroot_src/src/libstd/rt.rs:67
  14: std::rt::lang_start_internal::{{closure}}::{{closure}}
             at sysroot_src/src/libstd/rt.rs:52
```

This currently requires debuginfo to be enabled. It also doesn't work for jitted code.