### PR TITLE
Mark blocks that call cold funs as cold

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -300,6 +300,7 @@ fn codegen_fn_content(fx: &mut FunctionCx<'_, '_, impl Backend>) {
                 fx.tcx.sess.time("codegen call", || crate::abi::codegen_terminator_call(
                     fx,
                     bb_data.terminator().source_info.span,
+                    block,
                     func,
                     args,
                     *destination,


### PR DESCRIPTION
@bjorn3 I couldn't test this as I'm not getting any clif output even when I don't pass `--release` to `test.sh`.

I'm also not sure about how to format this code, it seems like the toolchain we use don't have rustfmt.