### PR TITLE
Dump clif with --emit llvm-ir in release mode

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -77,7 +77,6 @@ pub(crate) fn trans_fn<'clif, 'tcx, B: Backend + 'static>(
     let local_map = fx.local_map;
     let cold_blocks = fx.cold_blocks;
 
-    #[cfg(debug_assertions)]
     crate::pretty_clif::write_clif_file(cx.tcx, "unopt", instance, &context.func, &clif_comments, None);
 
     // Verify function
@@ -106,7 +105,6 @@ pub(crate) fn trans_fn<'clif, 'tcx, B: Backend + 'static>(
     );
 
     // Write optimized function to file for debugging
-    #[cfg(debug_assertions)]
     {
         let value_ranges = context
             .build_value_labels_ranges(cx.module.isa())

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -18,7 +18,6 @@ pub(crate) fn optimize_function<'tcx>(
         return; // FIXME classify optimizations over opt levels
     }
     self::stack2reg::optimize_function(ctx, clif_comments);
-    #[cfg(debug_assertions)]
     crate::pretty_clif::write_clif_file(tcx, "stack2reg", instance, &ctx.func, &*clif_comments, None);
     crate::base::verify_func(tcx, &*clif_comments, &ctx.func);
 }

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -6,6 +6,8 @@ use cranelift_codegen::{
     write::{FuncWriter, PlainWriter},
 };
 
+use rustc_session::config::OutputType;
+
 use crate::prelude::*;
 
 /// This module provides the [CommentWriter] which makes it possible
@@ -198,7 +200,6 @@ impl<B: Backend + 'static> FunctionCx<'_, '_, B> {
     }
 }
 
-#[cfg(debug_assertions)]
 pub(crate) fn write_clif_file<'tcx>(
     tcx: TyCtxt<'tcx>,
     postfix: &str,
@@ -207,6 +208,10 @@ pub(crate) fn write_clif_file<'tcx>(
     mut clif_comments: &CommentWriter,
     value_ranges: Option<&cranelift_codegen::ValueLabelsRanges>,
 ) {
+    if !(cfg!(debug_assertions) || tcx.sess.opts.output_types.contains_key(&OutputType::LlvmAssembly)) {
+        return;
+    }
+
     use std::io::Write;
 
     let symbol_name = tcx.symbol_name(instance).name.as_str();

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -208,7 +208,7 @@ pub(crate) fn write_clif_file<'tcx>(
     mut clif_comments: &CommentWriter,
     value_ranges: Option<&cranelift_codegen::ValueLabelsRanges>,
 ) {
-    if !(cfg!(debug_assertions) || tcx.sess.opts.output_types.contains_key(&OutputType::LlvmAssembly)) {
+    if !cfg!(debug_assertions) && !tcx.sess.opts.output_types.contains_key(&OutputType::LlvmAssembly) {
         return;
     }
 


### PR DESCRIPTION
Currently it's not possible to dump llvm-ir in release build. With this
patch we allow it with `--emit llvm-ir`. In debug build we dump clif
always as before.

Fixes #1020