### PR TITLE
Enforce linux style line endings to support WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
I found that if I clone this repo from windows, and run ./prepare.sh under WSL, the line endings cause errors and the script fails to run in multiple places.

This PR enforces linux style line endings on git checkout. Linux users won't notice any change. Windows users will no longer have this error, if like me, they checkout under windows but run under WSL.