### PR TITLE
Fix lld

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 [[package]]
 name = "cranelift-bforest"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "cranelift-entity",
 ]
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -79,17 +79,17 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 
 [[package]]
 name = "cranelift-frontend"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "cranelift-module"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "cranelift-object"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "cranelift-simplejit"
 version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#32db4dcbe98098e5be2e457339d6d1946c73225c"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
 dependencies = [
  "cranelift-codegen",
  "cranelift-module",

--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,9 @@ function jit_calc() {
     object files when their content should have been changed by a change to cg_clif.</dd>
     <dt>CG_CLIF_DISPLAY_CG_TIME</dt>
     <dd>If "1", display the time it took to perform codegen for a crate</dd>
+    <dt>CG_CLIF_FUNCTION_SECTIONS</dt>
+    <dd>Use a single section for each function. This will often reduce the executable size at the
+        cost of making linking significantly slower.</dd>
 </dl>
 
 ## Not yet supported

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -68,8 +68,17 @@ impl WriteDebugInfo for ObjectProduct {
         .into_bytes();
 
         let segment = self.object.segment_name(StandardSegment::Debug).to_vec();
-        let section_id = self.object.add_section(segment, name, SectionKind::Debug);
-        self.object.section_mut(section_id).set_data(data, 1);
+        // FIXME use SHT_X86_64_UNWIND for .eh_frame
+        let section_id = self.object.add_section(segment, name.clone(), if id == SectionId::EhFrame {
+            SectionKind::ReadOnlyData
+        } else {
+            SectionKind::Debug
+        });
+        self.object.section_mut(section_id).set_data(data, if id == SectionId::EhFrame {
+            8
+        } else {
+            1
+        });
         let symbol_id = self.object.section_symbol(section_id);
         (section_id, symbol_id)
     }
@@ -95,7 +104,7 @@ impl WriteDebugInfo for ObjectProduct {
                 Relocation {
                     offset: u64::from(reloc.offset),
                     symbol,
-                    kind: RelocationKind::Absolute,
+                    kind: reloc.kind,
                     encoding: RelocationEncoding::Generic,
                     size: reloc.size * 8,
                     addend: i64::try_from(symbol_offset).unwrap() + reloc.addend,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -186,13 +186,17 @@ pub(crate) type Backend =
     impl cranelift_module::Backend<Product: AddConstructor + Emit + WriteDebugInfo>;
 
 pub(crate) fn make_module(sess: &Session, name: String) -> Module<Backend> {
+    let mut builder = ObjectBuilder::new(
+        crate::build_isa(sess, true),
+        name + ".o",
+        cranelift_module::default_libcall_names(),
+    )
+    .unwrap();
+    if std::env::var("CG_CLIF_FUNCTION_SECTIONS").is_ok() {
+        builder.per_function_section(true);
+    }
     let module: Module<ObjectBackend> = Module::new(
-        ObjectBuilder::new(
-            crate::build_isa(sess, true),
-            name + ".o",
-            cranelift_module::default_libcall_names(),
-        )
-        .unwrap(),
+        builder,
     );
     module
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -274,7 +274,7 @@ fn data_id_for_alloc_id<B: Backend>(
 ) -> DataId {
     module
         .declare_data(
-            &format!("__alloc_{}", alloc_id.0),
+            &format!("__alloc_{:x}", alloc_id.0),
             Linkage::Local,
             mutability == rustc_hir::Mutability::Mut,
             false,

--- a/src/debuginfo/unwind.rs
+++ b/src/debuginfo/unwind.rs
@@ -16,7 +16,10 @@ impl<'tcx> UnwindContext<'tcx> {
     pub(crate) fn new(tcx: TyCtxt<'tcx>, isa: &dyn TargetIsa) -> Self {
         let mut frame_table = FrameTable::default();
 
-        let cie_id = if let Some(cie) = isa.create_systemv_cie() {
+        let cie_id = if let Some(mut cie) = isa.create_systemv_cie() {
+            if isa.flags().is_pic() {
+                cie.fde_address_encoding = gimli::DwEhPe(gimli::DW_EH_PE_pcrel.0 | gimli::DW_EH_PE_sdata4.0);
+            }
             Some(frame_table.add_cie(cie))
         } else {
             None


### PR DESCRIPTION
Lld doesn't allow dynamic relocations in readonly sections by default. This means that `.eh_frame` needs to use pcrel pointers. I also needed https://github.com/bytecodealliance/wasmtime/pull/2212 to fix readonly data objects with relocations that specify a custom section. As a bonus I also added support for https://github.com/bytecodealliance/wasmtime/pull/2218.

r? @philipc