### PR TITLE
Use the new cranelift-module interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,16 +43,16 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -69,8 +69,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -78,18 +78,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -99,8 +99,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -111,8 +111,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -121,26 +121,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
+ "log",
  "object",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-simplejit"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#1fabb051b0436a38f794ca395601dcdcc31d3c18"
+version = "0.67.0"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#88d975d396defb47da85665054a98a16708ef6df"
 dependencies = [
  "cranelift-codegen",
+ "cranelift-entity",
  "cranelift-module",
  "cranelift-native",
  "errno",
  "libc",
+ "log",
  "region",
  "target-lexicon",
  "winapi",
@@ -184,9 +187,9 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 dependencies = [
  "indexmap",
 ]
@@ -284,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.30"
+version = "0.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041c2d34f6ff346d6f428974f03d8bf12679b0c816bb640dc5eb1d48848d8d1"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
  "log",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-module = { git = "https://github.com/bytecodealliance/wasmtime/", bran
 cranelift-simplejit = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main", optional = true }
 cranelift-object = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main" }
 target-lexicon = "0.11.0"
-gimli = { version = "0.21.0", default-features = false, features = ["write"]}
+gimli = { version = "0.22.0", default-features = false, features = ["write"]}
 object = { version = "0.21.1", default-features = false, features = ["std", "read_core", "write", "coff", "elf", "macho", "pe"] }
 
 ar = { git = "https://github.com/bjorn3/rust-ar.git", branch = "do_not_remove_cg_clif_ranlib" }

--- a/src/abi/comments.rs
+++ b/src/abi/comments.rs
@@ -10,14 +10,14 @@ use cranelift_codegen::entity::EntityRef;
 use crate::abi::pass_mode::*;
 use crate::prelude::*;
 
-pub(super) fn add_args_header_comment(fx: &mut FunctionCx<'_, '_, impl Backend>) {
+pub(super) fn add_args_header_comment(fx: &mut FunctionCx<'_, '_, impl Module>) {
     fx.add_global_comment(format!(
         "kind  loc.idx   param    pass mode                            ty"
     ));
 }
 
 pub(super) fn add_arg_comment<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     kind: &str,
     local: Option<mir::Local>,
     local_field: Option<usize>,
@@ -54,7 +54,7 @@ pub(super) fn add_arg_comment<'tcx>(
     ));
 }
 
-pub(super) fn add_locals_header_comment(fx: &mut FunctionCx<'_, '_, impl Backend>) {
+pub(super) fn add_locals_header_comment(fx: &mut FunctionCx<'_, '_, impl Module>) {
     fx.add_global_comment(String::new());
     fx.add_global_comment(format!(
         "kind  local ty                              size align (abi,pref)"
@@ -62,7 +62,7 @@ pub(super) fn add_locals_header_comment(fx: &mut FunctionCx<'_, '_, impl Backend
 }
 
 pub(super) fn add_local_place_comments<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     place: CPlace<'tcx>,
     local: Local,
 ) {

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -238,7 +238,7 @@ pub(crate) fn get_function_name_and_sig<'tcx>(
 /// Instance must be monomorphized
 pub(crate) fn import_function<'tcx>(
     tcx: TyCtxt<'tcx>,
-    module: &mut Module<impl Backend>,
+    module: &mut impl Module,
     inst: Instance<'tcx>,
 ) -> FuncId {
     let (name, sig) = get_function_name_and_sig(tcx, module.isa().triple(), inst, true);
@@ -247,7 +247,7 @@ pub(crate) fn import_function<'tcx>(
         .unwrap()
 }
 
-impl<'tcx, B: Backend + 'static> FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> FunctionCx<'_, 'tcx, M> {
     /// Instance must be monomorphized
     pub(crate) fn get_function_ref(&mut self, inst: Instance<'tcx>) -> FuncRef {
         let func_id = import_function(self.tcx, &mut self.cx.module, inst);
@@ -329,7 +329,7 @@ impl<'tcx, B: Backend + 'static> FunctionCx<'_, 'tcx, B> {
 
 /// Make a [`CPlace`] capable of holding value of the specified type.
 fn make_local_place<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     local: Local,
     layout: TyAndLayout<'tcx>,
     is_ssa: bool,
@@ -351,7 +351,7 @@ fn make_local_place<'tcx>(
 }
 
 pub(crate) fn codegen_fn_prelude<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     start_block: Block,
 ) {
     let ssa_analyzed = crate::analyze::analyze(fx);
@@ -488,7 +488,7 @@ pub(crate) fn codegen_fn_prelude<'tcx>(
 }
 
 pub(crate) fn codegen_terminator_call<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     span: Span,
     current_block: Block,
     func: &Operand<'tcx>,
@@ -701,7 +701,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
 }
 
 pub(crate) fn codegen_drop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     span: Span,
     drop_place: CPlace<'tcx>,
 ) {

--- a/src/abi/pass_mode.rs
+++ b/src/abi/pass_mode.rs
@@ -122,7 +122,7 @@ pub(super) fn get_pass_mode<'tcx>(tcx: TyCtxt<'tcx>, layout: TyAndLayout<'tcx>) 
 
 /// Get a set of values to be passed as function arguments.
 pub(super) fn adjust_arg_for_abi<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     arg: CValue<'tcx>,
 ) -> EmptySinglePair<Value> {
     match get_pass_mode(fx.tcx, arg.layout()) {
@@ -142,7 +142,7 @@ pub(super) fn adjust_arg_for_abi<'tcx>(
 /// Create a [`CValue`] containing the value of a function parameter adding clif function parameters
 /// as necessary.
 pub(super) fn cvalue_for_param<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     start_block: Block,
     #[cfg_attr(not(debug_assertions), allow(unused_variables))] local: Option<mir::Local>,
     #[cfg_attr(not(debug_assertions), allow(unused_variables))] local_field: Option<usize>,

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -9,7 +9,7 @@ use rustc_span::symbol::sym;
 /// Returns whether an allocator shim was created
 pub(crate) fn codegen(
     tcx: TyCtxt<'_>,
-    module: &mut Module<impl Backend + 'static>,
+    module: &mut impl Module,
     unwind_context: &mut UnwindContext<'_>,
 ) -> bool {
     let any_dynamic_crate = tcx.dependency_formats(LOCAL_CRATE).iter().any(|(_, list)| {
@@ -27,7 +27,7 @@ pub(crate) fn codegen(
 }
 
 fn codegen_inner(
-    module: &mut Module<impl Backend + 'static>,
+    module: &mut impl Module,
     unwind_context: &mut UnwindContext<'_>,
     kind: AllocatorKind,
 ) {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -11,7 +11,7 @@ pub(crate) enum SsaKind {
     Ssa,
 }
 
-pub(crate) fn analyze(fx: &FunctionCx<'_, '_, impl Backend>) -> IndexVec<Local, SsaKind> {
+pub(crate) fn analyze(fx: &FunctionCx<'_, '_, impl Module>) -> IndexVec<Local, SsaKind> {
     let mut flag_map = fx
         .mir
         .local_decls

--- a/src/base.rs
+++ b/src/base.rs
@@ -5,8 +5,8 @@ use rustc_middle::ty::adjustment::PointerCast;
 
 use crate::prelude::*;
 
-pub(crate) fn trans_fn<'tcx, B: Backend + 'static>(
-    cx: &mut crate::CodegenCx<'tcx, B>,
+pub(crate) fn trans_fn<'tcx>(
+    cx: &mut crate::CodegenCx<'tcx, impl Module>,
     instance: Instance<'tcx>,
     linkage: Linkage,
 ) {
@@ -183,7 +183,7 @@ pub(crate) fn verify_func(
     });
 }
 
-fn codegen_fn_content(fx: &mut FunctionCx<'_, '_, impl Backend>) {
+fn codegen_fn_content(fx: &mut FunctionCx<'_, '_, impl Module>) {
     crate::constant::check_constants(fx);
 
     for (bb, bb_data) in fx.mir.basic_blocks().iter_enumerated() {
@@ -417,7 +417,7 @@ fn codegen_fn_content(fx: &mut FunctionCx<'_, '_, impl Backend>) {
 }
 
 fn trans_stmt<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     #[allow(unused_variables)] cur_block: Block,
     stmt: &Statement<'tcx>,
 ) {
@@ -543,7 +543,7 @@ fn trans_stmt<'tcx>(
                     let to_ty = fx.monomorphize(to_ty);
 
                     fn is_fat_ptr<'tcx>(
-                        fx: &FunctionCx<'_, 'tcx, impl Backend>,
+                        fx: &FunctionCx<'_, 'tcx, impl Module>,
                         ty: Ty<'tcx>,
                     ) -> bool {
                         ty.builtin_deref(true)
@@ -873,7 +873,7 @@ fn trans_stmt<'tcx>(
 }
 
 fn codegen_array_len<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     place: CPlace<'tcx>,
 ) -> Value {
     match *place.layout().ty.kind() {
@@ -893,7 +893,7 @@ fn codegen_array_len<'tcx>(
 }
 
 pub(crate) fn trans_place<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     place: Place<'tcx>,
 ) -> CPlace<'tcx> {
     let mut cplace = fx.get_local_place(place.local);
@@ -965,7 +965,7 @@ pub(crate) fn trans_place<'tcx>(
 }
 
 pub(crate) fn trans_operand<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     operand: &Operand<'tcx>,
 ) -> CValue<'tcx> {
     match operand {
@@ -978,7 +978,7 @@ pub(crate) fn trans_operand<'tcx>(
 }
 
 pub(crate) fn codegen_panic<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     msg_str: &str,
     span: Span,
 ) {
@@ -995,7 +995,7 @@ pub(crate) fn codegen_panic<'tcx>(
 }
 
 pub(crate) fn codegen_panic_inner<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     lang_item: rustc_hir::LangItem,
     args: &[Value],
     span: Span,

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 pub(crate) fn clif_intcast(
-    fx: &mut FunctionCx<'_, '_, impl Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     val: Value,
     to: Type,
     signed: bool,
@@ -51,7 +51,7 @@ pub(crate) fn clif_intcast(
 }
 
 pub(crate) fn clif_int_or_float_cast(
-    fx: &mut FunctionCx<'_, '_, impl Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     from: Value,
     from_signed: bool,
     to_ty: Type,

--- a/src/codegen_i128.rs
+++ b/src/codegen_i128.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 pub(crate) fn maybe_codegen<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     checked: bool,
     lhs: CValue<'tcx>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -131,7 +131,7 @@ pub(crate) fn has_ptr_meta<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
 }
 
 pub(crate) fn codegen_icmp_imm(
-    fx: &mut FunctionCx<'_, '_, impl Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     intcc: IntCC,
     lhs: Value,
     rhs: i128,
@@ -287,8 +287,8 @@ pub(crate) fn type_sign(ty: Ty<'_>) -> bool {
     }
 }
 
-pub(crate) struct FunctionCx<'clif, 'tcx, B: Backend + 'static> {
-    pub(crate) cx: &'clif mut crate::CodegenCx<'tcx, B>,
+pub(crate) struct FunctionCx<'clif, 'tcx, M: Module> {
+    pub(crate) cx: &'clif mut crate::CodegenCx<'tcx, M>,
     pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) pointer_type: Type, // Cached from module
 
@@ -314,7 +314,7 @@ pub(crate) struct FunctionCx<'clif, 'tcx, B: Backend + 'static> {
     pub(crate) inline_asm_index: u32,
 }
 
-impl<'tcx, B: Backend> LayoutOf for FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> LayoutOf for FunctionCx<'_, 'tcx, M> {
     type Ty = Ty<'tcx>;
     type TyAndLayout = TyAndLayout<'tcx>;
 
@@ -332,31 +332,31 @@ impl<'tcx, B: Backend> LayoutOf for FunctionCx<'_, 'tcx, B> {
     }
 }
 
-impl<'tcx, B: Backend + 'static> layout::HasTyCtxt<'tcx> for FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> layout::HasTyCtxt<'tcx> for FunctionCx<'_, 'tcx, M> {
     fn tcx<'b>(&'b self) -> TyCtxt<'tcx> {
         self.tcx
     }
 }
 
-impl<'tcx, B: Backend + 'static> rustc_target::abi::HasDataLayout for FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> rustc_target::abi::HasDataLayout for FunctionCx<'_, 'tcx, M> {
     fn data_layout(&self) -> &rustc_target::abi::TargetDataLayout {
         &self.tcx.data_layout
     }
 }
 
-impl<'tcx, B: Backend + 'static> layout::HasParamEnv<'tcx> for FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> layout::HasParamEnv<'tcx> for FunctionCx<'_, 'tcx, M> {
     fn param_env(&self) -> ParamEnv<'tcx> {
         ParamEnv::reveal_all()
     }
 }
 
-impl<'tcx, B: Backend + 'static> HasTargetSpec for FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> HasTargetSpec for FunctionCx<'_, 'tcx, M> {
     fn target_spec(&self) -> &Target {
         &self.tcx.sess.target.target
     }
 }
 
-impl<'tcx, B: Backend + 'static> FunctionCx<'_, 'tcx, B> {
+impl<'tcx, M: Module> FunctionCx<'_, 'tcx, M> {
     pub(crate) fn monomorphize<T>(&self, value: &T) -> T
     where
         T: TypeFoldable<'tcx> + Copy,
@@ -430,7 +430,6 @@ impl<'tcx, B: Backend + 'static> FunctionCx<'_, 'tcx, B> {
                 Linkage::Local,
                 false,
                 false,
-                None,
             )
             .unwrap();
 

--- a/src/debuginfo/emit.rs
+++ b/src/debuginfo/emit.rs
@@ -76,7 +76,7 @@ impl WriterRelocate {
     #[cfg(feature = "jit")]
     pub(super) fn relocate_for_jit(
         mut self,
-        jit_module: &mut cranelift_module::Module<cranelift_simplejit::SimpleJITBackend>,
+        jit_product: &cranelift_simplejit::SimpleJITProduct,
     ) -> Vec<u8> {
         use std::convert::TryInto;
 
@@ -84,7 +84,7 @@ impl WriterRelocate {
             match reloc.name {
                 super::DebugRelocName::Section(_) => unreachable!(),
                 super::DebugRelocName::Symbol(sym) => {
-                    let addr = jit_module.get_finalized_function(
+                    let addr = jit_product.lookup_func(
                         cranelift_module::FuncId::from_u32(sym.try_into().unwrap()),
                     );
                     let val = (addr as u64 as i64 + reloc.addend) as u64;

--- a/src/debuginfo/mod.rs
+++ b/src/debuginfo/mod.rs
@@ -336,6 +336,8 @@ impl<'tcx> DebugContext<'tcx> {
                 | ArgumentPurpose::CalleeSaved => continue,
                 ArgumentPurpose::VMContext
                 | ArgumentPurpose::SignatureId
+                | ArgumentPurpose::CallerTLS
+                | ArgumentPurpose::CalleeTLS
                 | ArgumentPurpose::StackLimit => unreachable!(),
             };
             let name = format!("{}{}", base_name, i);

--- a/src/debuginfo/unwind.rs
+++ b/src/debuginfo/unwind.rs
@@ -78,7 +78,7 @@ impl<'tcx> UnwindContext<'tcx> {
     #[cfg(feature = "jit")]
     pub(crate) unsafe fn register_jit(
         self,
-        jit_module: &mut Module<cranelift_simplejit::SimpleJITBackend>,
+        jit_product: &cranelift_simplejit::SimpleJITProduct,
     ) -> Option<UnwindRegistry> {
         let mut eh_frame = EhFrame::from(super::emit::WriterRelocate::new(super::target_endian(
             self.tcx,
@@ -89,7 +89,7 @@ impl<'tcx> UnwindContext<'tcx> {
             return None;
         }
 
-        let mut eh_frame = eh_frame.0.relocate_for_jit(jit_module);
+        let mut eh_frame = eh_frame.0.relocate_for_jit(jit_product);
 
         // GCC expects a terminating "empty" length, so write a 0 length at the end of the table.
         eh_frame.extend(&[0, 0, 0, 0]);

--- a/src/discriminant.rs
+++ b/src/discriminant.rs
@@ -7,7 +7,7 @@ use rustc_target::abi::{Int, TagEncoding, Variants};
 use crate::prelude::*;
 
 pub(crate) fn codegen_set_discriminant<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     place: CPlace<'tcx>,
     variant_index: VariantIdx,
 ) {
@@ -57,7 +57,7 @@ pub(crate) fn codegen_set_discriminant<'tcx>(
 }
 
 pub(crate) fn codegen_get_discriminant<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     value: CValue<'tcx>,
     dest_layout: TyAndLayout<'tcx>,
 ) -> CValue<'tcx> {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -41,7 +41,7 @@ pub(crate) fn codegen_crate(
 }
 
 fn codegen_mono_items<'tcx>(
-    cx: &mut crate::CodegenCx<'tcx, impl Backend + 'static>,
+    cx: &mut crate::CodegenCx<'tcx, impl Module>,
     mono_items: Vec<(MonoItem<'tcx>, (RLinkage, Visibility))>,
 ) {
     cx.tcx.sess.time("predefine functions", || {
@@ -68,8 +68,8 @@ fn codegen_mono_items<'tcx>(
     }
 }
 
-fn trans_mono_item<'tcx, B: Backend + 'static>(
-    cx: &mut crate::CodegenCx<'tcx, B>,
+fn trans_mono_item<'tcx, M: Module>(
+    cx: &mut crate::CodegenCx<'tcx, M>,
     mono_item: MonoItem<'tcx>,
     linkage: Linkage,
 ) {

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -9,7 +9,7 @@ use rustc_middle::mir::InlineAsmOperand;
 use rustc_target::asm::*;
 
 pub(crate) fn codegen_inline_asm<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     _span: Span,
     template: &[InlineAsmTemplatePiece],
     operands: &[InlineAsmOperand<'tcx>],
@@ -203,7 +203,7 @@ fn generate_asm_wrapper(
 }
 
 fn call_inline_asm<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     asm_name: &str,
     slot_size: Size,
     inputs: Vec<(InlineAsmReg, Size, Value)>,

--- a/src/intrinsics/cpuid.rs
+++ b/src/intrinsics/cpuid.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 ///
 /// This emulates an intel cpu with sse and sse2 support, but which doesn't support anything else.
 pub(crate) fn codegen_cpuid_call<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     leaf: Value,
     _subleaf: Value,
 ) -> (Value, Value, Value, Value) {

--- a/src/intrinsics/llvm.rs
+++ b/src/intrinsics/llvm.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 use rustc_middle::ty::subst::SubstsRef;
 
 pub(crate) fn codegen_llvm_intrinsic_call<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     intrinsic: &str,
     substs: SubstsRef<'tcx>,
     args: &[mir::Operand<'tcx>],

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -204,12 +204,12 @@ pub(crate) fn clif_vector_type<'tcx>(tcx: TyCtxt<'tcx>, layout: TyAndLayout<'tcx
     }
 }
 
-fn simd_for_each_lane<'tcx, B: Backend>(
-    fx: &mut FunctionCx<'_, 'tcx, B>,
+fn simd_for_each_lane<'tcx, M: Module>(
+    fx: &mut FunctionCx<'_, 'tcx, M>,
     val: CValue<'tcx>,
     ret: CPlace<'tcx>,
     f: impl Fn(
-        &mut FunctionCx<'_, 'tcx, B>,
+        &mut FunctionCx<'_, 'tcx, M>,
         TyAndLayout<'tcx>,
         TyAndLayout<'tcx>,
         Value,
@@ -231,13 +231,13 @@ fn simd_for_each_lane<'tcx, B: Backend>(
     }
 }
 
-fn simd_pair_for_each_lane<'tcx, B: Backend>(
-    fx: &mut FunctionCx<'_, 'tcx, B>,
+fn simd_pair_for_each_lane<'tcx, M: Module>(
+    fx: &mut FunctionCx<'_, 'tcx, M>,
     x: CValue<'tcx>,
     y: CValue<'tcx>,
     ret: CPlace<'tcx>,
     f: impl Fn(
-        &mut FunctionCx<'_, 'tcx, B>,
+        &mut FunctionCx<'_, 'tcx, M>,
         TyAndLayout<'tcx>,
         TyAndLayout<'tcx>,
         Value,
@@ -263,7 +263,7 @@ fn simd_pair_for_each_lane<'tcx, B: Backend>(
 }
 
 fn bool_to_zero_or_max_uint<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     layout: TyAndLayout<'tcx>,
     val: Value,
 ) -> CValue<'tcx> {
@@ -395,7 +395,7 @@ macro simd_flt_binop($fx:expr, $op:ident($x:ident, $y:ident) -> $ret:ident) {
 }
 
 pub(crate) fn codegen_intrinsic_call<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     instance: Instance<'tcx>,
     args: &[mir::Operand<'tcx>],
     destination: Option<(CPlace<'tcx>, BasicBlock)>,

--- a/src/intrinsics/simd.rs
+++ b/src/intrinsics/simd.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::prelude::*;
 
 pub(super) fn codegen_simd_intrinsic_call<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     instance: Instance<'tcx>,
     args: &[mir::Operand<'tcx>],
     ret: CPlace<'tcx>,

--- a/src/main_shim.rs
+++ b/src/main_shim.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 /// users main function.
 pub(crate) fn maybe_create_entry_wrapper(
     tcx: TyCtxt<'_>,
-    module: &mut Module<impl Backend + 'static>,
+    module: &mut impl Module,
     unwind_context: &mut UnwindContext<'_>,
     use_jit: bool,
 ) {
@@ -38,7 +38,7 @@ pub(crate) fn maybe_create_entry_wrapper(
 
     fn create_entry_fn(
         tcx: TyCtxt<'_>,
-        m: &mut Module<impl Backend + 'static>,
+        m: &mut impl Module,
         unwind_context: &mut UnwindContext<'_>,
         rust_main_def_id: DefId,
         use_start_lang_item: bool,

--- a/src/num.rs
+++ b/src/num.rs
@@ -41,7 +41,7 @@ pub(crate) fn bin_op_to_intcc(bin_op: BinOp, signed: bool) -> Option<IntCC> {
 }
 
 fn codegen_compare_bin_op<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     signed: bool,
     lhs: Value,
@@ -54,7 +54,7 @@ fn codegen_compare_bin_op<'tcx>(
 }
 
 pub(crate) fn codegen_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,
@@ -103,7 +103,7 @@ pub(crate) fn codegen_binop<'tcx>(
 }
 
 pub(crate) fn trans_bool_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,
@@ -124,7 +124,7 @@ pub(crate) fn trans_bool_binop<'tcx>(
 }
 
 pub(crate) fn trans_int_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,
@@ -197,7 +197,7 @@ pub(crate) fn trans_int_binop<'tcx>(
 }
 
 pub(crate) fn trans_checked_int_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,
@@ -358,7 +358,7 @@ pub(crate) fn trans_checked_int_binop<'tcx>(
 }
 
 pub(crate) fn trans_float_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,
@@ -403,7 +403,7 @@ pub(crate) fn trans_float_binop<'tcx>(
 }
 
 pub(crate) fn trans_ptr_binop<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     bin_op: BinOp,
     in_lhs: CValue<'tcx>,
     in_rhs: CValue<'tcx>,

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -37,7 +37,7 @@ impl Pointer {
     }
 
     pub(crate) fn const_addr<'a, 'tcx>(
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         addr: i64,
     ) -> Self {
         let addr = fx.bcx.ins().iconst(fx.pointer_type, addr);
@@ -59,7 +59,7 @@ impl Pointer {
         (self.base, self.offset)
     }
 
-    pub(crate) fn get_addr<'a, 'tcx>(self, fx: &mut FunctionCx<'a, 'tcx, impl Backend>) -> Value {
+    pub(crate) fn get_addr<'a, 'tcx>(self, fx: &mut FunctionCx<'a, 'tcx, impl Module>) -> Value {
         match self.base {
             PointerBase::Addr(base_addr) => {
                 let offset: i64 = self.offset.into();
@@ -83,7 +83,7 @@ impl Pointer {
 
     pub(crate) fn offset<'a, 'tcx>(
         self,
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         extra_offset: Offset32,
     ) -> Self {
         self.offset_i64(fx, extra_offset.into())
@@ -91,7 +91,7 @@ impl Pointer {
 
     pub(crate) fn offset_i64<'a, 'tcx>(
         self,
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         extra_offset: i64,
     ) -> Self {
         if let Some(new_offset) = self.offset.try_add_i64(extra_offset) {
@@ -128,7 +128,7 @@ impl Pointer {
 
     pub(crate) fn offset_value<'a, 'tcx>(
         self,
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         extra_offset: Value,
     ) -> Self {
         match self.base {
@@ -161,7 +161,7 @@ impl Pointer {
 
     pub(crate) fn load<'a, 'tcx>(
         self,
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         ty: Type,
         flags: MemFlags,
     ) -> Value {
@@ -182,7 +182,7 @@ impl Pointer {
 
     pub(crate) fn store<'a, 'tcx>(
         self,
-        fx: &mut FunctionCx<'a, 'tcx, impl Backend>,
+        fx: &mut FunctionCx<'a, 'tcx, impl Module>,
         value: Value,
         flags: MemFlags,
     ) {

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -186,7 +186,7 @@ impl FuncWriter for &'_ CommentWriter {
 }
 
 #[cfg(debug_assertions)]
-impl<B: Backend + 'static> FunctionCx<'_, '_, B> {
+impl<M: Module> FunctionCx<'_, '_, M> {
     pub(crate) fn add_global_comment<S: Into<String>>(&mut self, comment: S) {
         self.clif_comments.add_global_comment(comment);
     }
@@ -264,7 +264,7 @@ pub(crate) fn write_clif_file<'tcx>(
     }
 }
 
-impl<B: Backend + 'static> fmt::Debug for FunctionCx<'_, '_, B> {
+impl<M: Module> fmt::Debug for FunctionCx<'_, '_, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{:?}", self.instance.substs)?;
         writeln!(f, "{:?}", self.local_map)?;

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-fn codegen_print(fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>, msg: &str) {
+fn codegen_print(fx: &mut FunctionCx<'_, '_, impl Module>, msg: &str) {
     let puts = fx
         .cx
         .module
@@ -30,7 +30,7 @@ fn codegen_print(fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>, ms
 
 /// Trap code: user1
 pub(crate) fn trap_abort(
-    fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     msg: impl AsRef<str>,
 ) {
     codegen_print(fx, msg.as_ref());
@@ -42,7 +42,7 @@ pub(crate) fn trap_abort(
 ///
 /// Trap code: user65535
 pub(crate) fn trap_unreachable(
-    fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     msg: impl AsRef<str>,
 ) {
     codegen_print(fx, msg.as_ref());
@@ -53,7 +53,7 @@ pub(crate) fn trap_unreachable(
 ///
 /// Trap code: user65535
 pub(crate) fn trap_unreachable_ret_value<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl cranelift_module::Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     dest_layout: TyAndLayout<'tcx>,
     msg: impl AsRef<str>,
 ) -> CValue<'tcx> {
@@ -69,7 +69,7 @@ pub(crate) fn trap_unreachable_ret_value<'tcx>(
 ///
 /// Trap code: user65535
 pub(crate) fn trap_unimplemented(
-    fx: &mut FunctionCx<'_, '_, impl cranelift_module::Backend>,
+    fx: &mut FunctionCx<'_, '_, impl Module>,
     msg: impl AsRef<str>,
 ) {
     codegen_print(fx, msg.as_ref());
@@ -81,7 +81,7 @@ pub(crate) fn trap_unimplemented(
 ///
 /// Trap code: user65535
 pub(crate) fn trap_unimplemented_ret_value<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl cranelift_module::Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     dest_layout: TyAndLayout<'tcx>,
     msg: impl AsRef<str>,
 ) -> CValue<'tcx> {

--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 /// in an upcast, where the new vtable for an object will be derived
 /// from the old one.
 pub(crate) fn unsized_info<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     source: Ty<'tcx>,
     target: Ty<'tcx>,
     old_info: Option<Value>,
@@ -45,7 +45,7 @@ pub(crate) fn unsized_info<'tcx>(
 
 /// Coerce `src` to `dst_ty`. `src_ty` must be a thin pointer.
 fn unsize_thin_ptr<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     src: Value,
     src_layout: TyAndLayout<'tcx>,
     dst_layout: TyAndLayout<'tcx>,
@@ -89,7 +89,7 @@ fn unsize_thin_ptr<'tcx>(
 /// Coerce `src`, which is a reference to a value of type `src_ty`,
 /// to a value of type `dst_ty` and store the result in `dst`
 pub(crate) fn coerce_unsized_into<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     src: CValue<'tcx>,
     dst: CPlace<'tcx>,
 ) {
@@ -142,7 +142,7 @@ pub(crate) fn coerce_unsized_into<'tcx>(
 // Adapted from https://github.com/rust-lang/rust/blob/2a663555ddf36f6b041445894a8c175cd1bc718c/src/librustc_codegen_ssa/glue.rs
 
 pub(crate) fn size_and_align_of_dst<'tcx>(
-    fx: &mut FunctionCx<'_, 'tcx, impl Backend>,
+    fx: &mut FunctionCx<'_, 'tcx, impl Module>,
     layout: TyAndLayout<'tcx>,
     info: Value,
 ) -> (Value, Value) {


### PR DESCRIPTION
This updates Cranelift to include bytecodealliance/wasmtime#2249

From that PR:

> The old design has a Module struct that wraps around a Backend implementation. Because the Backend is not exposed it is not possible to export extra methods to do things like deallocating specific functions or adding new predefined imports for the jit. It is also not possible to customise the behavior of existing methods to for example allow replacing an already defined function for hot code swapping. It was also not possible to create a module with a non-static lifetime (required for headcrab-inject) In the new design Module is instead a trait with ModuleDeclarations being a struct for some shared behavior regarding how declarations are handled. As the Module is fully exposed, it is possible to add new methlds to the api of every module and customize the behavior of existing methods. None of the previously mentioned use cases are implemented yet. I will leave that for a future PR.