### PR TITLE
fix (many) shellcheck warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,15 +34,15 @@ else
     cargo build
 fi
 
-rm -rf $target_dir
-mkdir $target_dir
-cp -a target/$CHANNEL/cg_clif{,_build_sysroot} target/$CHANNEL/*rustc_codegen_cranelift* $target_dir/
-cp -a rust-toolchain scripts/config.sh scripts/cargo.sh $target_dir
+rm -rf "$target_dir"
+mkdir "$target_dir"
+cp -a target/$CHANNEL/cg_clif{,_build_sysroot} target/$CHANNEL/*rustc_codegen_cranelift* "$target_dir/"
+cp -a rust-toolchain scripts/config.sh scripts/cargo.sh "$target_dir"
 
 if [[ "$build_sysroot" == "1" ]]; then
     echo "[BUILD] sysroot"
     export CG_CLIF_INCR_CACHE_DISABLED=1
     dir=$(pwd)
-    cd $target_dir
-    time $dir/build_sysroot/build_sysroot.sh
+    cd "$target_dir"
+    time "$dir/build_sysroot/build_sysroot.sh"
 fi

--- a/build_sysroot/build_sysroot.sh
+++ b/build_sysroot/build_sysroot.sh
@@ -13,7 +13,7 @@ dir=$(pwd)
 export RUSTC=$dir"/cg_clif_build_sysroot"
 export RUSTFLAGS=$RUSTFLAGS" --clif"
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
 # Cleanup for previous run
 #     v Clean target dir except for build scripts and incremental cache
@@ -28,12 +28,12 @@ if [[ "$1" != "--debug" ]]; then
     sysroot_channel='release'
     # FIXME Enable incremental again once rust-lang/rust#74946 is fixed
     # FIXME Enable -Zmir-opt-level=2 again once it doesn't ice anymore
-    CARGO_INCREMENTAL=0 RUSTFLAGS="$RUSTFLAGS" cargo build --target $TARGET_TRIPLE --release
+    CARGO_INCREMENTAL=0 RUSTFLAGS="$RUSTFLAGS" cargo build --target "$TARGET_TRIPLE" --release
 else
     sysroot_channel='debug'
-    cargo build --target $TARGET_TRIPLE
+    cargo build --target "$TARGET_TRIPLE"
 fi
 
 # Copy files to sysroot
-mkdir -p $dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
-cp -a target/$TARGET_TRIPLE/$sysroot_channel/deps/* $dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib/
+mkdir -p "$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib/"
+cp -a "target/$TARGET_TRIPLE/$sysroot_channel/deps/"* "$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib/"

--- a/build_sysroot/prepare_sysroot_src.sh
+++ b/build_sysroot/prepare_sysroot_src.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
-SRC_DIR=$(dirname $(rustup which rustc))"/../lib/rustlib/src/rust/"
+SRC_DIR="$(dirname "$(rustup which rustc)")/../lib/rustlib/src/rust/"
 DST_DIR="sysroot_src"
 
-if [ ! -e $SRC_DIR ]; then
+if [ ! -e "$SRC_DIR" ]; then
     echo "Please install rust-src component"
     exit 1
 fi
 
 rm -rf $DST_DIR
 mkdir -p $DST_DIR/library
-cp -a $SRC_DIR/library $DST_DIR/
+cp -a "$SRC_DIR/library" $DST_DIR/
 
 pushd $DST_DIR
 echo "[GIT] init"
@@ -22,8 +22,8 @@ git add .
 echo "[GIT] commit"
 git commit -m "Initial commit" -q
 for file in $(ls ../../patches/ | grep -v patcha); do
-echo "[GIT] apply" $file
-git apply ../../patches/$file
+echo "[GIT] apply" "$file"
+git apply ../../patches/"$file"
 git add -A
 git commit --no-gpg-sign -m "Patch $file"
 done

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -10,7 +10,7 @@ cmd=$1
 shift || true
 
 if [[ "$cmd" = "jit" ]]; then
-cargo "+${TOOLCHAIN}" rustc $@ -- --jit
+cargo "+${TOOLCHAIN}" rustc "$@" -- --jit
 else
-cargo "+${TOOLCHAIN}" "$cmd" $@
+cargo "+${TOOLCHAIN}" "$cmd" "$@"
 fi

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 dir=$(dirname "$0")
-source $dir/config.sh
+source "$dir/config.sh"
 
 # read nightly compiler from rust-toolchain file
-TOOLCHAIN=$(cat $dir/rust-toolchain)
+TOOLCHAIN=$(cat "$dir/rust-toolchain")
 
 cmd=$1
 shift || true
 
 if [[ "$cmd" = "jit" ]]; then
-cargo +${TOOLCHAIN} rustc $@ -- --jit
+cargo "+${TOOLCHAIN}" rustc $@ -- --jit
 else
-cargo +${TOOLCHAIN} $cmd $@
+cargo "+${TOOLCHAIN}" "$cmd" $@
 fi

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,6 +1,6 @@
 set -e
 
-unamestr=`uname`
+unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
    dylib_ext='so'
 elif [[ "$unamestr" == 'Darwin' ]]; then
@@ -47,11 +47,11 @@ export RUSTDOCFLAGS=$linker' -Cpanic=abort -Zpanic-abort-tests '\
 '-Zcodegen-backend='$dir'/librustc_codegen_cranelift.'$dylib_ext' --sysroot '$dir'/sysroot'
 
 # FIXME remove once the atomic shim is gone
-if [[ `uname` == 'Darwin' ]]; then
+if [[ $(uname) == 'Darwin' ]]; then
    export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
 fi
 
-export LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/"$TARGET_TRIPLE"/lib"
+export LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
 export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 export CG_CLIF_DISPLAY_CG_TIME=1

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 unamestr=$(uname)
@@ -39,7 +41,7 @@ echo
 export RUSTC_WRAPPER=
 fi
 
-dir=$(cd $(dirname "$BASH_SOURCE"); pwd)
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 export RUSTC=$dir"/cg_clif"
 export RUSTFLAGS=$linker
@@ -51,7 +53,8 @@ if [[ $(uname) == 'Darwin' ]]; then
    export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
 fi
 
-export LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
+LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
+export LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 export CG_CLIF_DISPLAY_CG_TIME=1

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -e
 
 unamestr=$(uname)
@@ -53,8 +51,7 @@ if [[ $(uname) == 'Darwin' ]]; then
    export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
 fi
 
-LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
-export LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$dir:$(rustc --print sysroot)/lib:$dir/target/out:$dir/sysroot/lib/rustlib/$TARGET_TRIPLE/lib"
 export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 export CG_CLIF_DISPLAY_CG_TIME=1

--- a/scripts/rustup.sh
+++ b/scripts/rustup.sh
@@ -7,13 +7,13 @@ case $1 in
         TOOLCHAIN=$(date +%Y-%m-%d)
 
         echo "=> Installing new nightly"
-        rustup toolchain install --profile minimal nightly-${TOOLCHAIN} # Sanity check to see if the nightly exists
-        echo nightly-${TOOLCHAIN} > rust-toolchain
+        rustup toolchain install --profile minimal "nightly-${TOOLCHAIN}" # Sanity check to see if the nightly exists
+        echo "nightly-${TOOLCHAIN}" > rust-toolchain
         rustup component add rustfmt || true
 
         echo "=> Uninstalling all old nighlies"
-        for nightly in $(rustup toolchain list | grep nightly | grep -v $TOOLCHAIN | grep -v nightly-x86_64); do
-            rustup toolchain uninstall $nightly
+        for nightly in $(rustup toolchain list | grep nightly | grep -v "$TOOLCHAIN" | grep -v nightly-x86_64); do
+            rustup toolchain uninstall "$nightly"
         done
 
         ./clean_all.sh
@@ -30,9 +30,9 @@ case $1 in
 	cg_clif=$(pwd)
 	pushd ../rust
 	branch=update_cg_clif-$(date +%Y-%m-%d)
-	git checkout -b $branch
+	git checkout -b "$branch"
 	git subtree pull --prefix=compiler/rustc_codegen_cranelift/ https://github.com/bjorn3/rustc_codegen_cranelift.git master
-	git push -u my $branch
+	git push -u my "$branch"
 	popd
 	;;
     *)

--- a/scripts/test_bootstrap.sh
+++ b/scripts/test_bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname "$0")/../
+cd "$(dirname "$0")/../"
 
 ./build.sh
 source build/config.sh
@@ -11,7 +11,7 @@ git clone https://github.com/rust-lang/rust.git || true
 pushd rust
 git fetch
 git checkout -- .
-git checkout $(rustc -V | cut -d' ' -f3 | tr -d '(')
+git checkout "$(rustc -V | cut -d' ' -f3 | tr -d '(')"
 
 git apply - <<EOF
 diff --git a/.gitmodules b/.gitmodules

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,59 +8,59 @@ MY_RUSTC=$RUSTC" "$RUSTFLAGS" -L crate=target/out --out-dir target/out -Cdebugin
 
 function no_sysroot_tests() {
     echo "[BUILD] mini_core"
-    $MY_RUSTC example/mini_core.rs --crate-name mini_core --crate-type lib,dylib --target $TARGET_TRIPLE
+    $MY_RUSTC example/mini_core.rs --crate-name mini_core --crate-type lib,dylib --target "$TARGET_TRIPLE"
 
     echo "[BUILD] example"
-    $MY_RUSTC example/example.rs --crate-type lib --target $TARGET_TRIPLE
+    $MY_RUSTC example/example.rs --crate-type lib --target "$TARGET_TRIPLE"
 
     if [[ "$JIT_SUPPORTED" = "1" ]]; then
         echo "[JIT] mini_core_hello_world"
-        CG_CLIF_JIT_ARGS="abc bcd" $MY_RUSTC --jit example/mini_core_hello_world.rs --cfg jit --target $HOST_TRIPLE
+        CG_CLIF_JIT_ARGS="abc bcd" $MY_RUSTC --jit example/mini_core_hello_world.rs --cfg jit --target "$HOST_TRIPLE"
     else
         echo "[JIT] mini_core_hello_world (skipped)"
     fi
 
     echo "[AOT] mini_core_hello_world"
-    $MY_RUSTC example/mini_core_hello_world.rs --crate-name mini_core_hello_world --crate-type bin -g --target $TARGET_TRIPLE
+    $MY_RUSTC example/mini_core_hello_world.rs --crate-name mini_core_hello_world --crate-type bin -g --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/mini_core_hello_world abc bcd
     # (echo "break set -n main"; echo "run"; sleep 1; echo "si -c 10"; sleep 1; echo "frame variable") | lldb -- ./target/out/mini_core_hello_world abc bcd
 
     echo "[AOT] arbitrary_self_types_pointers_and_wrappers"
-    $MY_RUSTC example/arbitrary_self_types_pointers_and_wrappers.rs --crate-name arbitrary_self_types_pointers_and_wrappers --crate-type bin --target $TARGET_TRIPLE
+    $MY_RUSTC example/arbitrary_self_types_pointers_and_wrappers.rs --crate-name arbitrary_self_types_pointers_and_wrappers --crate-type bin --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/arbitrary_self_types_pointers_and_wrappers
 }
 
 function base_sysroot_tests() {
     echo "[AOT] alloc_example"
-    $MY_RUSTC example/alloc_example.rs --crate-type bin --target $TARGET_TRIPLE
+    $MY_RUSTC example/alloc_example.rs --crate-type bin --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/alloc_example
 
     if [[ "$JIT_SUPPORTED" = "1" ]]; then
         echo "[JIT] std_example"
-        $MY_RUSTC --jit example/std_example.rs --target $HOST_TRIPLE
+        $MY_RUSTC --jit example/std_example.rs --target "$HOST_TRIPLE"
     else
         echo "[JIT] std_example (skipped)"
     fi
 
     echo "[AOT] dst_field_align"
     # FIXME Re-add -Zmir-opt-level=2 once rust-lang/rust#67529 is fixed.
-    $MY_RUSTC example/dst-field-align.rs --crate-name dst_field_align --crate-type bin --target $TARGET_TRIPLE
+    $MY_RUSTC example/dst-field-align.rs --crate-name dst_field_align --crate-type bin --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/dst_field_align || (echo $?; false)
 
     echo "[AOT] std_example"
-    $MY_RUSTC example/std_example.rs --crate-type bin --target $TARGET_TRIPLE
+    $MY_RUSTC example/std_example.rs --crate-type bin --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/std_example arg
 
     echo "[AOT] subslice-patterns-const-eval"
-    $MY_RUSTC example/subslice-patterns-const-eval.rs --crate-type bin -Cpanic=abort --target $TARGET_TRIPLE
+    $MY_RUSTC example/subslice-patterns-const-eval.rs --crate-type bin -Cpanic=abort --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/subslice-patterns-const-eval
 
     echo "[AOT] track-caller-attribute"
-    $MY_RUSTC example/track-caller-attribute.rs --crate-type bin -Cpanic=abort --target $TARGET_TRIPLE
+    $MY_RUSTC example/track-caller-attribute.rs --crate-type bin -Cpanic=abort --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/track-caller-attribute
 
     echo "[AOT] mod_bench"
-    $MY_RUSTC example/mod_bench.rs --crate-type bin --target $TARGET_TRIPLE
+    $MY_RUSTC example/mod_bench.rs --crate-type bin --target "$TARGET_TRIPLE"
     $RUN_WRAPPER ./target/out/mod_bench
 
     pushd rand
@@ -73,13 +73,13 @@ function extended_sysroot_tests() {
     pushd simple-raytracer
     if [[ "$HOST_TRIPLE" = "$TARGET_TRIPLE" ]]; then
         echo "[BENCH COMPILE] ebobby/simple-raytracer"
-        hyperfine --runs ${RUN_RUNS:-10} --warmup 1 --prepare "cargo clean" \
+        hyperfine --runs "${RUN_RUNS:-10}" --warmup 1 --prepare "cargo clean" \
         "RUSTC=rustc RUSTFLAGS='' cargo build" \
         "../build/cargo.sh build"
 
         echo "[BENCH RUN] ebobby/simple-raytracer"
         cp ./target/debug/main ./raytracer_cg_clif
-        hyperfine --runs ${RUN_RUNS:-10} ./raytracer_cg_llvm ./raytracer_cg_clif
+        hyperfine --runs "${RUN_RUNS:-10}" ./raytracer_cg_llvm ./raytracer_cg_clif
     else
         echo "[BENCH COMPILE] ebobby/simple-raytracer (skipped)"
         echo "[COMPILE] ebobby/simple-raytracer"

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -4,7 +4,7 @@ set -e
 
 source build/config.sh
 export CG_CLIF_INCR_CACHE_DISABLED=1
-MY_RUSTC=$RUSTC" "$RUSTFLAGS" -L crate=target/out --out-dir target/out -Cdebuginfo=2"
+MY_RUSTC="$RUSTC $RUSTFLAGS -L crate=target/out --out-dir target/out -Cdebuginfo=2"
 
 function no_sysroot_tests() {
     echo "[BUILD] mini_core"

--- a/test.sh
+++ b/test.sh
@@ -3,13 +3,13 @@ set -e
 
 export RUSTFLAGS="-Zrun_dsymutil=no"
 
-./build.sh --without-sysroot $@
+./build.sh --without-sysroot "$@"
 
 rm -r target/out || true
 
 scripts/tests.sh no_sysroot
 
-./build.sh $@
+./build.sh "$@"
 
 scripts/tests.sh base_sysroot
 scripts/tests.sh extended_sysroot


### PR DESCRIPTION
Related issue: #1107 

The first commit fixes the 'machine applicable' shellcheck warnings, the second one fixes some manually.

There are still some warnings left:

```
In build_sysroot/prepare_sysroot_src.sh line 24:
for file in $(ls ../../patches/ | grep -v patcha); do
              ^-- SC2010: Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames.
```
I wasn't sure why you were ignoring 'patcha' here. Is this still needed?


```
In scripts/config.sh line 31:
      RUN_WRAPPER='wine'
      ^---------^ SC2034: RUN_WRAPPER appears unused. Verify use (or export if used externally).
```
Was this supposed to be used somewhere?


```
In scripts/rustup.sh line 30:
	cg_clif=$(pwd)
        ^-----^ SC2034: cg_clif appears unused. Verify use (or export if used externally).
```
Same as above.

```
In scripts/tests.sh line 102:
    cat examples/regexdna-input.txt | ../build/cargo.sh run --example shootout-regex-dna | grep -v "Spawned thread" > res.txt
        ^-------------------------^ SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
```
I think not using cat here makes readability worse.