### PR TITLE
Support building with the new Cranelift backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        env:
+          - BACKEND: ""
+          - BACKEND: --features newbe
 
     steps:
     - uses: actions/checkout@v2
@@ -51,7 +54,7 @@ jobs:
         export COMPILE_RUNS=2
         export RUN_RUNS=2
 
-        ./test.sh
+        ./test.sh $BACKEND
 
     - name: Package prebuilt cg_clif
       run: tar cvfJ cg_clif.tar.xz build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cranelift-bforest"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "cranelift-entity",
 ]
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -85,17 +85,17 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 
 [[package]]
 name = "cranelift-frontend"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "cranelift-jit"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "cranelift-module"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "cranelift-object"
 version = "0.69.0"
-source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#8640025d8b3b2ab5188ffc3f1a4b3976d49af3aa"
+source = "git+https://github.com/bytecodealliance/wasmtime/?branch=main#986b5768f9e68f1564b43f32b8a4080a6582c8ca"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["dylib"]
 
 [dependencies]
 # These have to be in sync with each other
-cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main", features = ["unwind"] }
+cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main", features = ["unwind", "x86", "x64"] }
 cranelift-frontend = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main" }
 cranelift-module = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main" }
 cranelift-jit = { git = "https://github.com/bytecodealliance/wasmtime/", branch = "main", optional = true }
@@ -37,6 +37,7 @@ libloading = { version = "0.6.0", optional = true }
 default = ["jit", "inline_asm"]
 jit = ["cranelift-jit", "libloading"]
 inline_asm = []
+newbe = []
 
 [profile.dev]
 # By compiling dependencies with optimizations, performing tests gets much faster.

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ set -e
 export CHANNEL="release"
 build_sysroot=1
 target_dir='build'
+newbe=''
 while [[ $# != 0 ]]; do
     case $1 in
         "--debug")
@@ -17,9 +18,12 @@ while [[ $# != 0 ]]; do
             target_dir=$2
             shift
             ;;
+        "--newbe")
+            newbe='--features newbe'
+            ;;
         *)
             echo "Unknown flag '$1'"
-            echo "Usage: ./build.sh [--debug] [--without-sysroot] [--target-dir DIR]"
+            echo "Usage: ./build.sh [--debug] [--without-sysroot] [--target-dir DIR] [--newbe]"
             ;;
     esac
     shift
@@ -39,9 +43,9 @@ else
    exit 1
 fi
 if [[ "$CHANNEL" == "release" ]]; then
-    cargo build --release
+    cargo build $newbe --release
 else
-    cargo build
+    cargo build $newbe
 fi
 
 rm -rf "$target_dir"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,12 @@ fn build_isa(sess: &Session) -> Box<dyn isa::TargetIsa + 'static> {
 
     let flags = settings::Flags::new(flags_builder);
 
-    let mut isa_builder = cranelift_codegen::isa::lookup(target_triple).unwrap();
+    let variant = if cfg!(feature = "newbe") {
+        cranelift_codegen::isa::BackendVariant::MachInst
+    } else {
+        cranelift_codegen::isa::BackendVariant::Legacy
+    };
+    let mut isa_builder = cranelift_codegen::isa::lookup_variant(target_triple, variant).unwrap();
     // Don't use "haswell", as it implies `has_lzcnt`.macOS CI is still at Ivy Bridge EP, so `lzcnt`
     // is interpreted as `bsr`.
     isa_builder.enable("nehalem").unwrap();


### PR DESCRIPTION
x64 newBE now has support for enough to make cg_clif usable with it. I plan to permanently switch over to the new backends in the near future but for now the old x86 backend is still the default.

cc @cfallin