### PR TITLE
Don't set RUSTFLAGS when no specific linker is needed

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -44,7 +44,11 @@ fi
 dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 export RUSTC=$dir"/bin/cg_clif"
-export RUSTFLAGS=$linker" "$RUSTFLAGS
+
+if [ ! -z $linker ]; then
+	export RUSTFLAGS=$linker" "$RUSTFLAGS
+fi
+
 export RUSTDOCFLAGS=$linker' -Cpanic=abort -Zpanic-abort-tests '\
 '-Zcodegen-backend='$dir'/lib/librustc_codegen_cranelift.'$dylib_ext' --sysroot '$dir
 


### PR DESCRIPTION
This allows the cargo.sh script to use the ~/.cargo/config if it exists it certain situations.