### PR TITLE
AArch64 support on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,9 @@ jobs:
         git config --global user.name "User"
         ./y.rs prepare
 
+    - name: Build
+      run: ./y.rs build --sysroot none
+
     - name: Test
       env:
         TARGET_TRIPLE: ${{ matrix.env.TARGET_TRIPLE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
           - os: ubuntu-latest
             env:
               TARGET_TRIPLE: x86_64-pc-windows-gnu
+          - os: ubuntu-latest
+            env:
+              TARGET_TRIPLE: aarch64-unknown-linux-gnu
 
     steps:
     - uses: actions/checkout@v2
@@ -48,6 +51,11 @@ jobs:
       run: |
         sudo apt-get install -y gcc-mingw-w64-x86-64 wine-stable
         rustup target add x86_64-pc-windows-gnu
+
+    - name: Install AArch64 toolchain and qemu
+      if: matrix.os == 'ubuntu-latest' && matrix.env.TARGET_TRIPLE == 'aarch64-unknown-linux-gnu'
+      run: |
+        sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user
 
     - name: Prepare dependencies
       run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "rust-analyzer.diagnostics.disabled": ["unresolved-extern-crate", "unresolved-macro-call"],
     "rust-analyzer.assist.importGranularity": "module",
     "rust-analyzer.assist.importEnforceGranularity": true,
-    "rust-analyzer.assist.importPrefix": "by_crate",
+    "rust-analyzer.assist.importPrefix": "crate",
     "rust-analyzer.cargo.runBuildScripts": true,
     "rust-analyzer.linkedProjects": [
         "./Cargo.toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cranelift-bforest"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "cranelift-entity",
 ]
@@ -42,7 +42,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -67,17 +67,17 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 
 [[package]]
 name = "cranelift-frontend"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -88,7 +88,7 @@ dependencies = [
 [[package]]
 name = "cranelift-jit"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "cranelift-module"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -116,16 +116,17 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "cranelift-codegen",
+ "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-object"
 version = "0.75.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#3d56728b8698d538a00d9f1c295149bbf5e8b78b"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#f2d2f3a841f4da8188df0a5f1033b5bdeaf02bcd"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -171,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -211,9 +212,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "object"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "crc32fast",
  "indexmap",

--- a/example/mini_core_hello_world.rs
+++ b/example/mini_core_hello_world.rs
@@ -292,7 +292,7 @@ fn main() {
     #[cfg(not(any(jit, windows)))]
     test_tls();
 
-    #[cfg(all(not(jit), target_os = "linux"))]
+    #[cfg(all(not(jit), target_arch = "x86_64", target_os = "linux"))]
     unsafe {
         global_asm_test();
     }
@@ -303,12 +303,12 @@ fn main() {
     assert_eq!(*REF1, *REF2);
 }
 
-#[cfg(all(not(jit), target_os = "linux"))]
+#[cfg(all(not(jit), target_arch = "x86_64", target_os = "linux"))]
 extern "C" {
     fn global_asm_test();
 }
 
-#[cfg(all(not(jit), target_os = "linux"))]
+#[cfg(all(not(jit), target_arch = "x86_64", target_os = "linux"))]
 global_asm! {
     "
     .global global_asm_test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,10 +287,12 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Box<dyn isa::Tar
         }
         None => {
             let mut builder =
-                cranelift_codegen::isa::lookup_variant(target_triple, variant).unwrap();
-            // Don't use "haswell" as the default, as it implies `has_lzcnt`.
-            // macOS CI is still at Ivy Bridge EP, so `lzcnt` is interpreted as `bsr`.
-            builder.enable("nehalem").unwrap();
+                cranelift_codegen::isa::lookup_variant(target_triple.clone(), variant).unwrap();
+            if target_triple.architecture == target_lexicon::Architecture::X86_64 {
+                // Don't use "haswell" as the default, as it implies `has_lzcnt`.
+                // macOS CI is still at Ivy Bridge EP, so `lzcnt` is interpreted as `bsr`.
+                builder.enable("nehalem").unwrap();
+            }
             builder
         }
     };


### PR DESCRIPTION
Thanks to @afonso360 Cranelift now supports everything on AArch64 that cg_clif needs when compiling for Linux. CI is currently testing cross-compilation. Native may work too, though I don't know if that would hit https://github.com/bjorn3/rustc_codegen_cranelift/issues/1060.