### PR TITLE
change instructions for manually compiling y.rs

### DIFF
--- a/y.rs
+++ b/y.rs
@@ -15,8 +15,8 @@ exec ${0/.rs/.bin} $@
 //! for example:
 //!
 //! ```shell
-//! $ rustc y.rs -o build/y.bin
-//! $ build/y.bin
+//! $ rustc y.rs -o y.bin
+//! $ ./y.bin
 //! ```
 //!
 //! # Naming


### PR DESCRIPTION
This prevents an error on windows where the `build_sysroot` function was trying to delete `y.exe`.