### PR TITLE
Improve inline asm support

### DIFF
--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -493,6 +493,10 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
 
     fn prologue(generated_asm: &mut String, arch: InlineAsmArch) {
         match arch {
+            InlineAsmArch::X86 => {
+                generated_asm.push_str("    push ebp\n");
+                generated_asm.push_str("    mov ebp,[esp+8]\n");
+            }
             InlineAsmArch::X86_64 => {
                 generated_asm.push_str("    push rbp\n");
                 generated_asm.push_str("    mov rbp,rdi\n");
@@ -503,6 +507,10 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
 
     fn epilogue(generated_asm: &mut String, arch: InlineAsmArch) {
         match arch {
+            InlineAsmArch::X86 => {
+                generated_asm.push_str("    pop ebp\n");
+                generated_asm.push_str("    ret\n");
+            }
             InlineAsmArch::X86_64 => {
                 generated_asm.push_str("    pop rbp\n");
                 generated_asm.push_str("    ret\n");
@@ -513,7 +521,7 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
 
     fn epilogue_noreturn(generated_asm: &mut String, arch: InlineAsmArch) {
         match arch {
-            InlineAsmArch::X86_64 => {
+            InlineAsmArch::X86 | InlineAsmArch::X86_64 => {
                 generated_asm.push_str("    ud2\n");
             }
             _ => unimplemented!("epilogue_noreturn for {:?}", arch),
@@ -527,6 +535,11 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
         offset: Size,
     ) {
         match arch {
+            InlineAsmArch::X86 => {
+                write!(generated_asm, "    mov [ebp+0x{:x}], ", offset.bytes()).unwrap();
+                reg.emit(generated_asm, InlineAsmArch::X86, None).unwrap();
+                generated_asm.push('\n');
+            }
             InlineAsmArch::X86_64 => {
                 write!(generated_asm, "    mov [rbp+0x{:x}], ", offset.bytes()).unwrap();
                 reg.emit(generated_asm, InlineAsmArch::X86_64, None).unwrap();
@@ -543,6 +556,11 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
         offset: Size,
     ) {
         match arch {
+            InlineAsmArch::X86 => {
+                generated_asm.push_str("    mov ");
+                reg.emit(generated_asm, InlineAsmArch::X86, None).unwrap();
+                writeln!(generated_asm, ", [ebp+0x{:x}]", offset.bytes()).unwrap();
+            }
             InlineAsmArch::X86_64 => {
                 generated_asm.push_str("    mov ");
                 reg.emit(generated_asm, InlineAsmArch::X86_64, None).unwrap();

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -42,8 +42,10 @@ pub(crate) fn codegen_inline_asm<'tcx>(
         assert_eq!(operands.len(), 4);
         let (leaf, eax_place) = match operands[1] {
             InlineAsmOperand::InOut { reg, late: true, ref in_value, out_place } => {
-                let reg = expect_reg(reg);
-                assert_eq!(reg, InlineAsmReg::X86(X86InlineAsmReg::ax));
+                assert_eq!(
+                    reg,
+                    InlineAsmRegOrRegClass::Reg(InlineAsmReg::X86(X86InlineAsmReg::ax))
+                );
                 (
                     crate::base::codegen_operand(fx, in_value).load_scalar(fx),
                     crate::base::codegen_place(fx, out_place.unwrap()),
@@ -65,8 +67,10 @@ pub(crate) fn codegen_inline_asm<'tcx>(
         };
         let (sub_leaf, ecx_place) = match operands[2] {
             InlineAsmOperand::InOut { reg, late: true, ref in_value, out_place } => {
-                let reg = expect_reg(reg);
-                assert_eq!(reg, InlineAsmReg::X86(X86InlineAsmReg::cx));
+                assert_eq!(
+                    reg,
+                    InlineAsmRegOrRegClass::Reg(InlineAsmReg::X86(X86InlineAsmReg::cx))
+                );
                 (
                     crate::base::codegen_operand(fx, in_value).load_scalar(fx),
                     crate::base::codegen_place(fx, out_place.unwrap()),
@@ -76,8 +80,10 @@ pub(crate) fn codegen_inline_asm<'tcx>(
         };
         let edx_place = match operands[3] {
             InlineAsmOperand::Out { reg, late: true, place } => {
-                let reg = expect_reg(reg);
-                assert_eq!(reg, InlineAsmReg::X86(X86InlineAsmReg::dx));
+                assert_eq!(
+                    reg,
+                    InlineAsmRegOrRegClass::Reg(InlineAsmReg::X86(X86InlineAsmReg::dx))
+                );
                 crate::base::codegen_place(fx, place.unwrap())
             }
             _ => unreachable!(),
@@ -434,13 +440,6 @@ fn call_inline_asm<'tcx>(
         let ty = fx.clif_type(place.layout().ty).unwrap();
         let value = fx.bcx.ins().stack_load(ty, stack_slot, i32::try_from(offset.bytes()).unwrap());
         place.write_cvalue(fx, CValue::by_val(value, place.layout()));
-    }
-}
-
-fn expect_reg(reg_or_class: InlineAsmRegOrRegClass) -> InlineAsmReg {
-    match reg_or_class {
-        InlineAsmRegOrRegClass::Reg(reg) => reg,
-        InlineAsmRegOrRegClass::RegClass(class) => unimplemented!("{:?}", class),
     }
 }
 

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -438,6 +438,9 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
                     generated_asm.push_str(s);
                 }
                 InlineAsmTemplatePiece::Placeholder { operand_idx, modifier, span: _ } => {
+                    if self.options.contains(InlineAsmOptions::ATT_SYNTAX) {
+                        generated_asm.push('%');
+                    }
                     self.registers[*operand_idx]
                         .unwrap()
                         .emit(&mut generated_asm, self.arch, *modifier)

--- a/src/inline_asm.rs
+++ b/src/inline_asm.rs
@@ -108,7 +108,7 @@ pub(crate) fn codegen_inline_asm<'tcx>(
 
     let mut asm_gen = InlineAssemblyGenerator {
         tcx: fx.tcx,
-        arch: InlineAsmArch::X86_64,
+        arch: fx.tcx.sess.asm_arch.unwrap(),
         template,
         operands,
         options,
@@ -306,12 +306,8 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
         let mut slots_output = vec![None; self.operands.len()];
 
         let new_slot_fn = |slot_size: &mut Size, reg_class: InlineAsmRegClass| {
-            let reg_size = reg_class
-                .supported_types(InlineAsmArch::X86_64)
-                .iter()
-                .map(|(ty, _)| ty.size())
-                .max()
-                .unwrap();
+            let reg_size =
+                reg_class.supported_types(self.arch).iter().map(|(ty, _)| ty.size()).max().unwrap();
             let align = rustc_target::abi::Align::from_bytes(reg_size.bytes()).unwrap();
             let offset = slot_size.align_to(align);
             *slot_size = offset + reg_size;


### PR DESCRIPTION
Fix part of #1204 

> * [X]  Support register classes. This will require writing a mini register allocator to solve all register constraints.
> * [X]  Optimize
>   * [X]  Overlap input and output stack slots.
>   * [X]  Skip saving caller saved registers.
> * [ ]  Support more architectures
>   * [X]  32bit x86
>   * [X]  riscv32/64
>   * [ ]  ...
