### PR TITLE
Only enable JIT tests on x86_64

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -9,7 +9,16 @@ export HOST_TRIPLE=$(rustc -vV | grep host | cut -d: -f2 | tr -d " ")
 export TARGET_TRIPLE=${TARGET_TRIPLE:-$HOST_TRIPLE}
 
 export RUN_WRAPPER=''
-export JIT_SUPPORTED=1
+
+case "$TARGET_TRIPLE" in
+   x86_64*)
+      export JIT_SUPPORTED=1
+      ;;
+   *)
+      export JIT_SUPPORTED=0
+      ;;
+esac
+
 if [[ "$HOST_TRIPLE" != "$TARGET_TRIPLE" ]]; then
    export JIT_SUPPORTED=0
    if [[ "$TARGET_TRIPLE" == "aarch64-unknown-linux-gnu" ]]; then


### PR DESCRIPTION
Cranelift currently only supports JIT on x86_64 targets.
Disable JIT tests on all other targets, so that failing tests are
ignored.

Originally reported in https://github.com/rust-lang/rust/pull/96437. 