### PR TITLE
Fix `no_sysroot` testsuite for MSVC environments

### DIFF
--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -465,7 +465,7 @@ impl TestRunner {
         out_dir.push("out");
 
         let is_native = host_triple == target_triple;
-        let jit_supported = target_triple.contains("x86_64") && is_native;
+        let jit_supported = target_triple.contains("x86_64") && is_native && !host_triple.contains("windows");
 
         let mut rust_flags = env::var("RUSTFLAGS").ok().unwrap_or("".to_string());
         let mut run_wrapper = Vec::new();

--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -575,11 +575,19 @@ pub mod intrinsics {
 }
 
 pub mod libc {
+    // With the new Universal CRT, msvc has switched to all the printf functions being inline wrapper
+    // functions. legacy_stdio_definitions.lib which provides the printf wrapper functions as normal
+    // symbols to link against.
+    #[cfg_attr(unix, link(name = "c"))]
+    #[cfg_attr(target_env="msvc", link(name="legacy_stdio_definitions"))]
+    extern "C" {
+        pub fn printf(format: *const i8, ...) -> i32;
+    }
+
     #[cfg_attr(unix, link(name = "c"))]
     #[cfg_attr(target_env = "msvc", link(name = "msvcrt"))]
     extern "C" {
         pub fn puts(s: *const i8) -> i32;
-        pub fn printf(format: *const i8, ...) -> i32;
         pub fn malloc(size: usize) -> *mut u8;
         pub fn free(ptr: *mut u8);
         pub fn memcpy(dst: *mut u8, src: *const u8, size: usize);

--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -535,7 +535,7 @@ unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
 }
 
 #[lang = "box_free"]
-unsafe fn box_free<T: ?Sized>(ptr: Unique<T>, alloc: ()) {
+unsafe fn box_free<T: ?Sized>(ptr: Unique<T>, _alloc: ()) {
     libc::free(ptr.pointer.0 as *mut u8);
 }
 


### PR DESCRIPTION
👋 Hey,

This PR fixes the `no_sysroot` testsuite for windows.

It disables JIT tests. I haven't investigated those, but we seem to have some linking issues.

Links with the correct library for `printf` in `ucrt`.

Uses the MSVC `CreateThread` functions for the TLS tests.
