### PR TITLE
Add abi-checker to y.rs and run it on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,11 +105,6 @@ jobs:
 
         ./y.rs test
 
-
-    - name: Run abi-checker
-      if: matrix.env.TARGET_TRIPLE == ''
-      run: ./y.rs abi-checker
-
     - name: Package prebuilt cg_clif
       run: tar cvfJ cg_clif.tar.xz build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,11 @@ jobs:
 
         ./y.rs test
 
+
+    - name: Run abi-checker
+      if: matrix.env.TARGET_TRIPLE == ''
+      run: ./y.rs abi-checker
+
     - name: Package prebuilt cg_clif
       run: tar cvfJ cg_clif.tar.xz build
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ perf.data.old
 /regex
 /simple-raytracer
 /portable-simd
+/abi-checker

--- a/build_system/abi_checker.rs
+++ b/build_system/abi_checker.rs
@@ -1,4 +1,5 @@
 use super::build_sysroot;
+use super::config;
 use super::utils::spawn_and_wait_with_input;
 use build_system::SysrootKind;
 use std::env;
@@ -13,10 +14,15 @@ pub(crate) fn run(
     host_triple: &str,
     target_triple: &str,
 ) {
-    assert_eq!(
-        host_triple, target_triple,
-        "abi-checker not supported on cross-compilation scenarios"
-    );
+    if !config::get_bool("testsuite.abi-checker") {
+        eprintln!("[SKIP] abi-checker");
+        return;
+    }
+
+    if host_triple != target_triple {
+        eprintln!("[SKIP] abi-checker (cross-compilation not supported)");
+        return;
+    }
 
     eprintln!("Building sysroot for abi-checker");
     build_sysroot::build_sysroot(

--- a/build_system/abi_checker.rs
+++ b/build_system/abi_checker.rs
@@ -1,0 +1,67 @@
+use super::build_sysroot;
+use super::utils::spawn_and_wait_with_input;
+use build_system::SysrootKind;
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn run(
+    channel: &str,
+    sysroot_kind: SysrootKind,
+    target_dir: &Path,
+    cg_clif_build_dir: &Path,
+    host_triple: &str,
+    target_triple: &str,
+) {
+    assert_eq!(
+        host_triple, target_triple,
+        "abi-checker not supported on cross-compilation scenarios"
+    );
+
+    eprintln!("Building sysroot for abi-checker");
+    build_sysroot::build_sysroot(
+        channel,
+        sysroot_kind,
+        target_dir,
+        cg_clif_build_dir,
+        host_triple,
+        target_triple,
+    );
+
+    eprintln!("Running abi-checker");
+    let mut abi_checker_path = env::current_dir().unwrap();
+    abi_checker_path.push("abi-checker");
+    env::set_current_dir(abi_checker_path.clone()).unwrap();
+
+    let build_dir = abi_checker_path.parent().unwrap().join("build");
+    let cg_clif_dylib_path = build_dir.join(if cfg!(windows) { "bin" } else { "lib" }).join(
+        env::consts::DLL_PREFIX.to_string() + "rustc_codegen_cranelift" + env::consts::DLL_SUFFIX,
+    );
+    println!("cg_clif_dylib_path: {}", cg_clif_dylib_path.display());
+
+    let pairs = ["rustc_calls_cgclif", "cgclif_calls_rustc", "cgclif_calls_cc", "cc_calls_cgclif"];
+
+    for pair in pairs {
+        eprintln!("[ABI-CHECKER] Running pair {pair}");
+
+        let mut cmd = Command::new("cargo");
+        cmd.arg("run");
+        cmd.arg("--target");
+        cmd.arg(target_triple);
+        cmd.arg("--");
+        cmd.arg("--pairs");
+        cmd.arg(pair);
+        cmd.arg("--add-rustc-codegen-backend");
+        cmd.arg(format!("cgclif:{}", cg_clif_dylib_path.display()));
+
+        let output = spawn_and_wait_with_input(cmd, "".to_string());
+
+        // TODO: The correct thing to do here is to check the exit code, but abi-checker
+        // currently doesn't return 0 on success, so check for the test fail count.
+        // See: https://github.com/Gankra/abi-checker/issues/10
+        let failed = !(output.contains("0 failed") && output.contains("0 completely failed"));
+        if failed {
+            panic!("abi-checker for pair {} failed!", pair);
+        }
+    }
+}

--- a/build_system/abi_checker.rs
+++ b/build_system/abi_checker.rs
@@ -1,6 +1,6 @@
 use super::build_sysroot;
 use super::config;
-use super::utils::spawn_and_wait_with_input;
+use super::utils::spawn_and_wait;
 use build_system::SysrootKind;
 use std::env;
 use std::path::Path;
@@ -56,13 +56,5 @@ pub(crate) fn run(
     cmd.arg("--add-rustc-codegen-backend");
     cmd.arg(format!("cgclif:{}", cg_clif_dylib_path.display()));
 
-    let output = spawn_and_wait_with_input(cmd, "".to_string());
-
-    // TODO: The correct thing to do here is to check the exit code, but abi-checker
-    // currently doesn't return 0 on success, so check for the test fail count.
-    // See: https://github.com/Gankra/abi-checker/issues/10
-    let failed = !(output.contains("0 failed") && output.contains("0 completely failed"));
-    if failed {
-        panic!("abi-checker failed!");
-    }
+    spawn_and_wait(cmd);
 }

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -4,6 +4,7 @@ use std::process;
 
 use self::utils::is_ci;
 
+mod abi_checker;
 mod build_backend;
 mod build_sysroot;
 mod config;
@@ -21,6 +22,9 @@ fn usage() {
     eprintln!(
         "  ./y.rs test [--debug] [--sysroot none|clif|llvm] [--target-dir DIR] [--no-unstable-features]"
     );
+    eprintln!(
+        "  ./y.rs abi-checker [--debug] [--sysroot none|clif|llvm] [--target-dir DIR] [--no-unstable-features]"
+    );
 }
 
 macro_rules! arg_error {
@@ -35,6 +39,7 @@ macro_rules! arg_error {
 enum Command {
     Build,
     Test,
+    AbiChecker,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -66,6 +71,7 @@ pub fn main() {
         }
         Some("build") => Command::Build,
         Some("test") => Command::Test,
+        Some("abi-checker") => Command::AbiChecker,
         Some(flag) if flag.starts_with('-') => arg_error!("Expected command found flag {}", flag),
         Some(command) => arg_error!("Unknown command {}", command),
         None => {
@@ -144,6 +150,16 @@ pub fn main() {
         }
         Command::Build => {
             build_sysroot::build_sysroot(
+                channel,
+                sysroot_kind,
+                &target_dir,
+                &cg_clif_build_dir,
+                &host_triple,
+                &target_triple,
+            );
+        }
+        Command::AbiChecker => {
+            abi_checker::run(
                 channel,
                 sysroot_kind,
                 &target_dir,

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -22,9 +22,6 @@ fn usage() {
     eprintln!(
         "  ./y.rs test [--debug] [--sysroot none|clif|llvm] [--target-dir DIR] [--no-unstable-features]"
     );
-    eprintln!(
-        "  ./y.rs abi-checker [--debug] [--sysroot none|clif|llvm] [--target-dir DIR] [--no-unstable-features]"
-    );
 }
 
 macro_rules! arg_error {
@@ -39,7 +36,6 @@ macro_rules! arg_error {
 enum Command {
     Build,
     Test,
-    AbiChecker,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -71,7 +67,6 @@ pub fn main() {
         }
         Some("build") => Command::Build,
         Some("test") => Command::Test,
-        Some("abi-checker") => Command::AbiChecker,
         Some(flag) if flag.starts_with('-') => arg_error!("Expected command found flag {}", flag),
         Some(command) => arg_error!("Unknown command {}", command),
         None => {
@@ -147,9 +142,8 @@ pub fn main() {
                 &host_triple,
                 &target_triple,
             );
-        }
-        Command::Build => {
-            build_sysroot::build_sysroot(
+
+            abi_checker::run(
                 channel,
                 sysroot_kind,
                 &target_dir,
@@ -158,8 +152,8 @@ pub fn main() {
                 &target_triple,
             );
         }
-        Command::AbiChecker => {
-            abi_checker::run(
+        Command::Build => {
+            build_sysroot::build_sysroot(
                 channel,
                 sysroot_kind,
                 &target_dir,

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -15,6 +15,13 @@ pub(crate) fn prepare() {
     Command::new("cargo").arg("install").arg("hyperfine").spawn().unwrap().wait().unwrap();
 
     clone_repo_shallow_github(
+        "abi-checker",
+        "Gankra",
+        "abi-checker",
+        "7c1571da6e43f9a37347623e7d5c7d51be664a7b",
+    );
+
+    clone_repo_shallow_github(
         "rand",
         "rust-random",
         "rand",

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -18,7 +18,7 @@ pub(crate) fn prepare() {
         "abi-checker",
         "Gankra",
         "abi-checker",
-        "7c1571da6e43f9a37347623e7d5c7d51be664a7b",
+        "a2232d45f202846f5c02203c9f27355360f9a2ff",
     );
 
     clone_repo_shallow_github(

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -20,6 +20,7 @@ pub(crate) fn prepare() {
         "abi-checker",
         "a2232d45f202846f5c02203c9f27355360f9a2ff",
     );
+    apply_patches("abi-checker", Path::new("abi-checker"));
 
     clone_repo_shallow_github(
         "rand",

--- a/clean_all.sh
+++ b/clean_all.sh
@@ -3,4 +3,4 @@ set -e
 
 rm -rf build_sysroot/{sysroot_src/,target/,compiler-builtins/,rustc_version}
 rm -rf target/ build/ perf.data{,.old} y.bin
-rm -rf rand/ regex/ simple-raytracer/ portable-simd/
+rm -rf rand/ regex/ simple-raytracer/ portable-simd/ abi-checker/

--- a/config.txt
+++ b/config.txt
@@ -48,3 +48,5 @@ test.libcore
 test.regex-shootout-regex-dna
 test.regex
 test.portable-simd
+
+testsuite.abi-checker

--- a/patches/0029-abi-checker-Disable-failing-tests.patch
+++ b/patches/0029-abi-checker-Disable-failing-tests.patch
@@ -1,0 +1,36 @@
+From 1a315ba225577dbbd1f449d9609f16f984f68708 Mon Sep 17 00:00:00 2001
+From: Afonso Bordado <afonso360@users.noreply.github.com>
+Date: Fri, 12 Aug 2022 22:51:58 +0000
+Subject: [PATCH] Disable abi-checker tests
+
+---
+ src/report.rs | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/report.rs b/src/report.rs
+index 7346f5e..8347762 100644
+--- a/src/report.rs
++++ b/src/report.rs
+@@ -45,6 +45,20 @@ pub fn get_test_rules(test: &TestKey, caller: &dyn AbiImpl, callee: &dyn AbiImpl
+     //
+     // THIS AREA RESERVED FOR VENDORS TO APPLY PATCHES
+
++    // Currently MSVC has some broken ABI issues. Furthermore, they cause
++    // a STATUS_ACCESS_VIOLATION, so we can't even run them. Ensure that they compile and link.
++    if cfg!(windows) && (test.test_name == "bool" || test.test_name == "ui128") {
++        result.run = Link;
++        result.check = Pass(Link);
++    }
++
++    // structs is broken in the current release of cranelift for aarch64.
++    // It has been fixed for cranelift 0.88: https://github.com/bytecodealliance/wasmtime/pull/4634
++    if cfg!(target_arch = "aarch64") && test.test_name == "structs" {
++        result.run = Link;
++        result.check = Pass(Link);
++    }
++
+     // END OF VENDOR RESERVED AREA
+     //
+     //
+--
+2.34.1


### PR DESCRIPTION
👋 Hey,

I've been playing around with abi-checker since I think the MSVC failures are ABI related.

This PR adds CI support for abi-checker. Currently we only run it in native scenarios (i.e. no cross compile).

Failures so far:
#### [`ubuntu-latest` fails on pair `cgclif_calls_cc`](https://github.com/afonso360/rustc_codegen_cranelift/runs/7705655328?check_suite_focus=true#step:12:15505):
```
Test ui128::c::rustc_calls_cc::u128_val_in_3_perturbed_small        passed
Test ui128::c::rustc_calls_cc::u128_val_in_0_perturbed_big          failed!
test 170 arg3 field 0 mismatch 
caller: [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 3A, 3B, 3C, 3D, 3E, 3F] 
callee: [38, 39, 3A, 3B, 3C, 3D, 3E, 3F, 40, 41, 42, 43, 44, 45, 46, 47]
Test ui128::c::rustc_calls_cc::u128_val_in_1_perturbed_big          failed!
test 171 arg3 field 0 mismatch 
caller: [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 3A, 3B, 3C, 3D, 3E, 3F] 
callee: [38, 39, 3A, 3B, 3C, 3D, 3E, 3F, 40, 41, 42, 43, 44, 45, 46, 47]
Test ui128::c::rustc_calls_cc::u128_val_in_2_perturbed_big          failed!
...
```

#### Segfault on native `aarch64-unknown-linux-gnu` for pair `rustc_calls_cgclif`:
```
skipping ptr::vectorcall::rustc_calls_rustc: rustc doesn't support convention vectorcall
generating structs::c::rustc_calls_rustc
compiling  structs::c::rustc_calls_rustc
running    structs::c::rustc_calls_rustc
Segmentation fault (core dumped)
```


#### `STATUS_ACCESS_VIOLATION` for MSVC on pair `rustc_calls_cgclif`:
```
generating bool::c::rustc_calls_rustc
compiling  bool::c::rustc_calls_rustc
running    bool::c::rustc_calls_rustc
error: process didn't exit successfully: `target\debug\abi-checker.exe --pairs cgclif_calls_rustc --add-rustc-codegen-backend cgclif:C:\Users\Afonso\CLionProjects\rustc_codegen_cranelift\build\bin\rus
tc_codegen_cranelift.dll` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

---

I suspect that the aarch64 failures may be related to the issues we were having on #1184 but haven't investigated so far.

Edit(bjorn3): Fixes https://github.com/bjorn3/rustc_codegen_cranelift/issues/1251