### PR TITLE
Fix alignment flag for emit_small_memory_copy

### DIFF
--- a/src/value_and_place.rs
+++ b/src/value_and_place.rs
@@ -614,7 +614,7 @@ impl<'tcx> CPlace<'tcx> {
                     dst_align,
                     src_align,
                     true,
-                    MemFlags::trusted(),
+                    flags,
                 );
             }
             CValueInner::ByRef(_, Some(_)) => todo!(),


### PR DESCRIPTION
Do not unconditionally pass the "aligned" MemFlag when calling
emit_small_memory_copy.  Instead, allow the back end to rely on
the alignment info passed separately to this routine.

FYI @bjorn3 - this is needed in addition to https://github.com/bytecodealliance/wasmtime/pull/4702 to fix alignment issues on s390x.