### PR TITLE
Use `stack_store` instead of `stack_addr`+`store` when building structs

### DIFF
--- a/src/abi/pass_mode.rs
+++ b/src/abi/pass_mode.rs
@@ -193,7 +193,7 @@ pub(super) fn from_casted_value<'tcx>(
         // larger alignment than the integer.
         size: (std::cmp::max(abi_param_size, layout_size) + 15) / 16 * 16,
     });
-    let ptr = Pointer::new(fx.bcx.ins().stack_addr(pointer_ty(fx.tcx), stack_slot, 0));
+    let ptr = Pointer::stack_slot(stack_slot);
     let mut offset = 0;
     let mut block_params_iter = block_params.iter().copied();
     for param in abi_params {


### PR DESCRIPTION
👋 Hey,

When building structs for calling functions we currently emit a `stack_addr` and a `store`, this is a little bit verbose and it annoyed me a little bit when looking at the generated clif code.

This changes the ABI building code to use a `stack_store` instead.

The previous code looks something like this:
```
    v10 = iconst.i8 1
; write_cvalue: Addr(Pointer { base: Stack(ss0), offset: Offset32(13) }, None): bool <- ByVal(v10): bool
    v30 = stack_addr.i64 ss0+13
    store notrap aligned v10, v30
```

And now we generate this:
```
     v10 = iconst.i8 1
; write_cvalue: Addr(Pointer { base: Stack(ss0), offset: Offset32(13) }, None): bool <- ByVal(v10): bool
    stack_store v10, ss0+13
```

Which is slightly nicer to read.

It doesn't make a lot of difference, since after optimizations it goes back to the `stack_addr` + `store` format anyway