### PR TITLE
Refactorings for enabling parallel compilation (part 2)

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -214,10 +214,10 @@ fn compile_fn<'tcx>(
     let unwind_context = &mut cx.unwind_context;
     cx.profiler.verbose_generic_activity("generate debug info").run(|| {
         if let Some(debug_context) = debug_context {
-            debug_context.define_function(
+            debug_context.define_function(codegened_func.symbol_name.name).finalize(
+                debug_context,
                 tcx,
                 codegened_func.func_id,
-                codegened_func.symbol_name.name,
                 context,
                 codegened_func.function_span,
                 &codegened_func.source_info_set,

--- a/src/base.rs
+++ b/src/base.rs
@@ -24,7 +24,7 @@ struct CodegenedFunction<'tcx> {
 
 pub(crate) fn codegen_and_compile_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
-    cx: &mut crate::CodegenCx<'tcx>,
+    cx: &mut crate::CodegenCx,
     cached_context: &mut Context,
     module: &mut dyn Module,
     instance: Instance<'tcx>,
@@ -35,12 +35,12 @@ pub(crate) fn codegen_and_compile_fn<'tcx>(
     let cached_func = std::mem::replace(&mut cached_context.func, Function::new());
     let codegened_func = codegen_fn(tcx, cx, cached_func, module, instance);
 
-    compile_fn(cx, cached_context, module, codegened_func);
+    compile_fn(tcx, cx, cached_context, module, codegened_func);
 }
 
 fn codegen_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
-    cx: &mut crate::CodegenCx<'tcx>,
+    cx: &mut crate::CodegenCx,
     cached_func: Function,
     module: &mut dyn Module,
     instance: Instance<'tcx>,
@@ -132,7 +132,8 @@ fn codegen_fn<'tcx>(
 }
 
 fn compile_fn<'tcx>(
-    cx: &mut crate::CodegenCx<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    cx: &mut crate::CodegenCx,
     cached_context: &mut Context,
     module: &mut dyn Module,
     codegened_func: CodegenedFunction<'tcx>,
@@ -214,6 +215,7 @@ fn compile_fn<'tcx>(
     cx.profiler.verbose_generic_activity("generate debug info").run(|| {
         if let Some(debug_context) = debug_context {
             debug_context.define_function(
+                tcx,
                 codegened_func.func_id,
                 codegened_func.symbol_name.name,
                 context,

--- a/src/base.rs
+++ b/src/base.rs
@@ -148,7 +148,7 @@ fn compile_fn<'tcx>(
 ) {
     let tcx = cx.tcx;
 
-    let mut clif_comments = codegened_func.clif_comments;
+    let clif_comments = codegened_func.clif_comments;
 
     // Store function in context
     let context = cached_context;
@@ -164,17 +164,6 @@ fn compile_fn<'tcx>(
     // Some Cranelift optimizations expect the domtree to not yet be computed and as such don't
     // invalidate it when it would change.
     context.domtree.clear();
-
-    // Perform rust specific optimizations
-    tcx.sess.time("optimize clif ir", || {
-        crate::optimize::optimize_function(
-            tcx,
-            module.isa(),
-            codegened_func.instance,
-            context,
-            &mut clif_comments,
-        );
-    });
 
     #[cfg(any())] // This is never true
     let _clif_guard = {

--- a/src/base.rs
+++ b/src/base.rs
@@ -20,7 +20,6 @@ struct CodegenedFunction<'tcx> {
     func: Function,
     clif_comments: CommentWriter,
     source_info_set: IndexSet<SourceInfo>,
-    local_map: IndexVec<mir::Local, CPlace<'tcx>>,
 }
 
 pub(crate) fn codegen_and_compile_fn<'tcx>(
@@ -112,7 +111,6 @@ fn codegen_fn<'tcx>(
     let instance = fx.instance;
     let clif_comments = fx.clif_comments;
     let source_info_set = fx.source_info_set;
-    let local_map = fx.local_map;
 
     fx.constants_cx.finalize(fx.tcx, &mut *fx.module);
 
@@ -130,15 +128,7 @@ fn codegen_fn<'tcx>(
     // Verify function
     verify_func(tcx, &clif_comments, &func);
 
-    CodegenedFunction {
-        instance,
-        symbol_name,
-        func_id,
-        func,
-        clif_comments,
-        source_info_set,
-        local_map,
-    }
+    CodegenedFunction { instance, symbol_name, func_id, func, clif_comments, source_info_set }
 }
 
 fn compile_fn<'tcx>(
@@ -227,10 +217,8 @@ fn compile_fn<'tcx>(
                 codegened_func.instance,
                 codegened_func.func_id,
                 codegened_func.symbol_name.name,
-                isa,
                 context,
                 &codegened_func.source_info_set,
-                codegened_func.local_map,
             );
         }
         unwind_context.add_function(codegened_func.func_id, &context, isa);

--- a/src/base.rs
+++ b/src/base.rs
@@ -85,7 +85,7 @@ fn codegen_fn<'tcx>(
     let clif_comments = crate::pretty_clif::CommentWriter::new(tcx, instance);
 
     let func_debug_cx = if let Some(debug_context) = &mut cx.debug_context {
-        Some(debug_context.define_function(symbol_name.name))
+        Some(debug_context.define_function(tcx, symbol_name.name, mir.span))
     } else {
         None
     };

--- a/src/base.rs
+++ b/src/base.rs
@@ -119,9 +119,9 @@ fn codegen_fn<'tcx>(
 
     crate::pretty_clif::write_clif_file(
         tcx,
+        symbol_name.name,
         "unopt",
         module.isa(),
-        instance,
         &func,
         &clif_comments,
     );
@@ -201,9 +201,9 @@ fn compile_fn<'tcx>(
     // Write optimized function to file for debugging
     crate::pretty_clif::write_clif_file(
         tcx,
+        codegened_func.symbol_name.name,
         "opt",
         module.isa(),
-        codegened_func.instance,
         &context.func,
         &clif_comments,
     );
@@ -211,7 +211,7 @@ fn compile_fn<'tcx>(
     if let Some(disasm) = &context.mach_compile_result.as_ref().unwrap().disasm {
         crate::pretty_clif::write_ir_file(
             tcx,
-            || format!("{}.vcode", tcx.symbol_name(codegened_func.instance).name),
+            || format!("{}.vcode", codegened_func.symbol_name.name),
             |file| file.write_all(disasm.as_bytes()),
         )
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -232,7 +232,7 @@ pub(crate) fn type_sign(ty: Ty<'_>) -> bool {
 }
 
 pub(crate) struct FunctionCx<'m, 'clif, 'tcx: 'm> {
-    pub(crate) cx: &'clif mut crate::CodegenCx<'tcx>,
+    pub(crate) cx: &'clif mut crate::CodegenCx,
     pub(crate) module: &'m mut dyn Module,
     pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) target_config: TargetFrontendConfig, // Cached from module

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,7 @@ use rustc_target::abi::{Integer, Primitive};
 use rustc_target::spec::{HasTargetSpec, Target};
 
 use crate::constant::ConstantCx;
+use crate::debuginfo::FunctionDebugContext;
 use crate::prelude::*;
 
 pub(crate) fn pointer_ty(tcx: TyCtxt<'_>) -> types::Type {
@@ -238,6 +239,7 @@ pub(crate) struct FunctionCx<'m, 'clif, 'tcx: 'm> {
     pub(crate) target_config: TargetFrontendConfig, // Cached from module
     pub(crate) pointer_type: Type,                  // Cached from module
     pub(crate) constants_cx: ConstantCx,
+    pub(crate) func_debug_cx: Option<FunctionDebugContext>,
 
     pub(crate) instance: Instance<'tcx>,
     pub(crate) symbol_name: SymbolName<'tcx>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,13 @@
 use cranelift_codegen::isa::TargetFrontendConfig;
+use gimli::write::FileId;
+
+use rustc_data_structures::sync::Lrc;
 use rustc_index::vec::IndexVec;
 use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOfHelpers,
 };
 use rustc_middle::ty::SymbolName;
+use rustc_span::SourceFile;
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{Integer, Primitive};
 use rustc_target::spec::{HasTargetSpec, Target};
@@ -254,7 +258,11 @@ pub(crate) struct FunctionCx<'m, 'clif, 'tcx: 'm> {
     pub(crate) caller_location: Option<CValue<'tcx>>,
 
     pub(crate) clif_comments: crate::pretty_clif::CommentWriter,
-    pub(crate) source_info_set: indexmap::IndexSet<SourceInfo>,
+
+    /// Last accessed source file and it's debuginfo file id.
+    ///
+    /// For optimization purposes only
+    pub(crate) last_source_file: Option<(Lrc<SourceFile>, FileId)>,
 
     /// This should only be accessed by `CPlace::new_var`.
     pub(crate) next_ssa_var: u32,
@@ -338,8 +346,31 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
     }
 
     pub(crate) fn set_debug_loc(&mut self, source_info: mir::SourceInfo) {
-        let (index, _) = self.source_info_set.insert_full(source_info);
-        self.bcx.set_srcloc(SourceLoc::new(index as u32));
+        if let Some(debug_context) = &mut self.cx.debug_context {
+            let (file, line, column) =
+                DebugContext::get_span_loc(self.tcx, self.mir.span, source_info.span);
+
+            // add_source_file is very slow.
+            // Optimize for the common case of the current file not being changed.
+            let mut cached_file_id = None;
+            if let Some((ref last_source_file, last_file_id)) = self.last_source_file {
+                // If the allocations are not equal, the files may still be equal, but that
+                // doesn't matter, as this is just an optimization.
+                if rustc_data_structures::sync::Lrc::ptr_eq(last_source_file, &file) {
+                    cached_file_id = Some(last_file_id);
+                }
+            }
+
+            let file_id = if let Some(file_id) = cached_file_id {
+                file_id
+            } else {
+                debug_context.add_source_file(&file)
+            };
+
+            let source_loc =
+                self.func_debug_cx.as_mut().unwrap().add_dbg_loc(file_id, line, column);
+            self.bcx.set_srcloc(source_loc);
+        }
     }
 
     // Note: must be kept in sync with get_caller_location from cg_ssa

--- a/src/debuginfo/emit.rs
+++ b/src/debuginfo/emit.rs
@@ -9,7 +9,7 @@ use gimli::{RunTimeEndian, SectionId};
 use super::object::WriteDebugInfo;
 use super::DebugContext;
 
-impl DebugContext<'_> {
+impl DebugContext {
     pub(crate) fn emit(&mut self, product: &mut ObjectProduct) {
         let unit_range_list_id = self.dwarf.unit.ranges.add(self.unit_range_list.clone());
         let root = self.dwarf.unit.root();

--- a/src/debuginfo/line_info.rs
+++ b/src/debuginfo/line_info.rs
@@ -96,9 +96,9 @@ fn line_program_add_file(
     }
 }
 
-impl<'tcx> DebugContext<'tcx> {
-    pub(super) fn emit_location(&mut self, entry_id: UnitEntryId, span: Span) {
-        let loc = self.tcx.sess.source_map().lookup_char_pos(span.lo());
+impl DebugContext {
+    fn emit_location(&mut self, tcx: TyCtxt<'_>, entry_id: UnitEntryId, span: Span) {
+        let loc = tcx.sess.source_map().lookup_char_pos(span.lo());
 
         let file_id = line_program_add_file(
             &mut self.dwarf.unit.line_program,
@@ -115,13 +115,13 @@ impl<'tcx> DebugContext<'tcx> {
 
     pub(super) fn create_debug_lines(
         &mut self,
+        tcx: TyCtxt<'_>,
         symbol: usize,
         entry_id: UnitEntryId,
         context: &Context,
         function_span: Span,
         source_info_set: &indexmap::IndexSet<SourceInfo>,
     ) -> CodeOffset {
-        let tcx = self.tcx;
         let line_program = &mut self.dwarf.unit.line_program;
 
         let line_strings = &mut self.dwarf.line_strings;
@@ -211,7 +211,7 @@ impl<'tcx> DebugContext<'tcx> {
         );
         entry.set(gimli::DW_AT_high_pc, AttributeValue::Udata(u64::from(func_end)));
 
-        self.emit_location(entry_id, function_span);
+        self.emit_location(tcx, entry_id, function_span);
 
         func_end
     }

--- a/src/debuginfo/mod.rs
+++ b/src/debuginfo/mod.rs
@@ -97,14 +97,13 @@ impl<'tcx> DebugContext<'tcx> {
 
     pub(crate) fn define_function(
         &mut self,
-        instance: Instance<'tcx>,
         func_id: FuncId,
         name: &str,
         context: &Context,
+        function_span: Span,
         source_info_set: &indexmap::IndexSet<SourceInfo>,
     ) {
         let symbol = func_id.as_u32() as usize;
-        let mir = self.tcx.instance_mir(instance.def);
 
         // FIXME: add to appropriate scope instead of root
         let scope = self.dwarf.unit.root();
@@ -116,7 +115,8 @@ impl<'tcx> DebugContext<'tcx> {
         entry.set(gimli::DW_AT_name, AttributeValue::StringRef(name_id));
         entry.set(gimli::DW_AT_linkage_name, AttributeValue::StringRef(name_id));
 
-        let end = self.create_debug_lines(symbol, entry_id, context, mir.span, source_info_set);
+        let end =
+            self.create_debug_lines(symbol, entry_id, context, function_span, source_info_set);
 
         self.unit_range_list.0.push(Range::StartLength {
             begin: Address::Symbol { symbol, addend: 0 },

--- a/src/debuginfo/mod.rs
+++ b/src/debuginfo/mod.rs
@@ -7,18 +7,11 @@ mod unwind;
 
 use crate::prelude::*;
 
-use rustc_index::vec::IndexVec;
-
-use cranelift_codegen::entity::EntityRef;
-use cranelift_codegen::ir::{Endianness, LabelValueLoc, ValueLabel};
+use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::TargetIsa;
-use cranelift_codegen::ValueLocRange;
 
-use gimli::write::{
-    Address, AttributeValue, DwarfUnit, Expression, LineProgram, LineString, Location,
-    LocationList, Range, RangeList, UnitEntryId,
-};
-use gimli::{Encoding, Format, LineEncoding, RunTimeEndian, X86_64};
+use gimli::write::{Address, AttributeValue, DwarfUnit, LineProgram, LineString, Range, RangeList};
+use gimli::{Encoding, Format, LineEncoding, RunTimeEndian};
 
 pub(crate) use emit::{DebugReloc, DebugRelocName};
 pub(crate) use unwind::UnwindContext;
@@ -30,8 +23,6 @@ pub(crate) struct DebugContext<'tcx> {
 
     dwarf: DwarfUnit,
     unit_range_list: RangeList,
-
-    types: FxHashMap<Ty<'tcx>, UnitEntryId>,
 }
 
 impl<'tcx> DebugContext<'tcx> {
@@ -101,113 +92,7 @@ impl<'tcx> DebugContext<'tcx> {
             root.set(gimli::DW_AT_low_pc, AttributeValue::Address(Address::Constant(0)));
         }
 
-        DebugContext {
-            tcx,
-
-            endian,
-
-            dwarf,
-            unit_range_list: RangeList(Vec::new()),
-
-            types: FxHashMap::default(),
-        }
-    }
-
-    fn dwarf_ty(&mut self, ty: Ty<'tcx>) -> UnitEntryId {
-        if let Some(type_id) = self.types.get(&ty) {
-            return *type_id;
-        }
-
-        let new_entry = |dwarf: &mut DwarfUnit, tag| dwarf.unit.add(dwarf.unit.root(), tag);
-
-        let primitive = |dwarf: &mut DwarfUnit, ate| {
-            let type_id = new_entry(dwarf, gimli::DW_TAG_base_type);
-            let type_entry = dwarf.unit.get_mut(type_id);
-            type_entry.set(gimli::DW_AT_encoding, AttributeValue::Encoding(ate));
-            type_id
-        };
-
-        let name = format!("{}", ty);
-        let layout = self.tcx.layout_of(ParamEnv::reveal_all().and(ty)).unwrap();
-
-        let type_id = match ty.kind() {
-            ty::Bool => primitive(&mut self.dwarf, gimli::DW_ATE_boolean),
-            ty::Char => primitive(&mut self.dwarf, gimli::DW_ATE_UTF),
-            ty::Uint(_) => primitive(&mut self.dwarf, gimli::DW_ATE_unsigned),
-            ty::Int(_) => primitive(&mut self.dwarf, gimli::DW_ATE_signed),
-            ty::Float(_) => primitive(&mut self.dwarf, gimli::DW_ATE_float),
-            ty::Ref(_, pointee_ty, _mutbl)
-            | ty::RawPtr(ty::TypeAndMut { ty: pointee_ty, mutbl: _mutbl }) => {
-                let type_id = new_entry(&mut self.dwarf, gimli::DW_TAG_pointer_type);
-
-                // Ensure that type is inserted before recursing to avoid duplicates
-                self.types.insert(ty, type_id);
-
-                let pointee = self.dwarf_ty(*pointee_ty);
-
-                let type_entry = self.dwarf.unit.get_mut(type_id);
-
-                //type_entry.set(gimli::DW_AT_mutable, AttributeValue::Flag(mutbl == rustc_hir::Mutability::Mut));
-                type_entry.set(gimli::DW_AT_type, AttributeValue::UnitRef(pointee));
-
-                type_id
-            }
-            ty::Adt(adt_def, _substs) if adt_def.is_struct() && !layout.is_unsized() => {
-                let type_id = new_entry(&mut self.dwarf, gimli::DW_TAG_structure_type);
-
-                // Ensure that type is inserted before recursing to avoid duplicates
-                self.types.insert(ty, type_id);
-
-                let variant = adt_def.non_enum_variant();
-
-                for (field_idx, field_def) in variant.fields.iter().enumerate() {
-                    let field_offset = layout.fields.offset(field_idx);
-                    let field_layout = layout.field(
-                        &layout::LayoutCx { tcx: self.tcx, param_env: ParamEnv::reveal_all() },
-                        field_idx,
-                    );
-
-                    let field_type = self.dwarf_ty(field_layout.ty);
-
-                    let field_id = self.dwarf.unit.add(type_id, gimli::DW_TAG_member);
-                    let field_entry = self.dwarf.unit.get_mut(field_id);
-
-                    field_entry.set(
-                        gimli::DW_AT_name,
-                        AttributeValue::String(field_def.name.as_str().to_string().into_bytes()),
-                    );
-                    field_entry.set(
-                        gimli::DW_AT_data_member_location,
-                        AttributeValue::Udata(field_offset.bytes()),
-                    );
-                    field_entry.set(gimli::DW_AT_type, AttributeValue::UnitRef(field_type));
-                }
-
-                type_id
-            }
-            _ => new_entry(&mut self.dwarf, gimli::DW_TAG_structure_type),
-        };
-
-        let type_entry = self.dwarf.unit.get_mut(type_id);
-
-        type_entry.set(gimli::DW_AT_name, AttributeValue::String(name.into_bytes()));
-        type_entry.set(gimli::DW_AT_byte_size, AttributeValue::Udata(layout.size.bytes()));
-
-        self.types.insert(ty, type_id);
-
-        type_id
-    }
-
-    fn define_local(&mut self, scope: UnitEntryId, name: String, ty: Ty<'tcx>) -> UnitEntryId {
-        let dw_ty = self.dwarf_ty(ty);
-
-        let var_id = self.dwarf.unit.add(scope, gimli::DW_TAG_variable);
-        let var_entry = self.dwarf.unit.get_mut(var_id);
-
-        var_entry.set(gimli::DW_AT_name, AttributeValue::String(name.into_bytes()));
-        var_entry.set(gimli::DW_AT_type, AttributeValue::UnitRef(dw_ty));
-
-        var_id
+        DebugContext { tcx, endian, dwarf, unit_range_list: RangeList(Vec::new()) }
     }
 
     pub(crate) fn define_function(
@@ -215,10 +100,8 @@ impl<'tcx> DebugContext<'tcx> {
         instance: Instance<'tcx>,
         func_id: FuncId,
         name: &str,
-        isa: &dyn TargetIsa,
         context: &Context,
         source_info_set: &indexmap::IndexSet<SourceInfo>,
-        local_map: IndexVec<mir::Local, CPlace<'tcx>>,
     ) {
         let symbol = func_id.as_u32() as usize;
         let mir = self.tcx.instance_mir(instance.def);
@@ -248,110 +131,5 @@ impl<'tcx> DebugContext<'tcx> {
         );
         // Using Udata for DW_AT_high_pc requires at least DWARF4
         func_entry.set(gimli::DW_AT_high_pc, AttributeValue::Udata(u64::from(end)));
-
-        // FIXME make it more reliable and implement scopes before re-enabling this.
-        if false {
-            let value_labels_ranges = std::collections::HashMap::new(); // FIXME
-
-            for (local, _local_decl) in mir.local_decls.iter_enumerated() {
-                let ty = self.tcx.subst_and_normalize_erasing_regions(
-                    instance.substs,
-                    ty::ParamEnv::reveal_all(),
-                    mir.local_decls[local].ty,
-                );
-                let var_id = self.define_local(entry_id, format!("{:?}", local), ty);
-
-                let location = place_location(
-                    self,
-                    isa,
-                    symbol,
-                    &local_map,
-                    &value_labels_ranges,
-                    Place { local, projection: ty::List::empty() },
-                );
-
-                let var_entry = self.dwarf.unit.get_mut(var_id);
-                var_entry.set(gimli::DW_AT_location, location);
-            }
-        }
-
-        // FIXME create locals for all entries in mir.var_debug_info
-    }
-}
-
-fn place_location<'tcx>(
-    debug_context: &mut DebugContext<'tcx>,
-    isa: &dyn TargetIsa,
-    symbol: usize,
-    local_map: &IndexVec<mir::Local, CPlace<'tcx>>,
-    #[allow(rustc::default_hash_types)] value_labels_ranges: &std::collections::HashMap<
-        ValueLabel,
-        Vec<ValueLocRange>,
-    >,
-    place: Place<'tcx>,
-) -> AttributeValue {
-    assert!(place.projection.is_empty()); // FIXME implement them
-
-    match local_map[place.local].inner() {
-        CPlaceInner::Var(_local, var) => {
-            let value_label = cranelift_codegen::ir::ValueLabel::new(var.index());
-            if let Some(value_loc_ranges) = value_labels_ranges.get(&value_label) {
-                let loc_list = LocationList(
-                    value_loc_ranges
-                        .iter()
-                        .map(|value_loc_range| Location::StartEnd {
-                            begin: Address::Symbol {
-                                symbol,
-                                addend: i64::from(value_loc_range.start),
-                            },
-                            end: Address::Symbol { symbol, addend: i64::from(value_loc_range.end) },
-                            data: translate_loc(isa, value_loc_range.loc).unwrap(),
-                        })
-                        .collect(),
-                );
-                let loc_list_id = debug_context.dwarf.unit.locations.add(loc_list);
-
-                AttributeValue::LocationListRef(loc_list_id)
-            } else {
-                // FIXME set value labels for unused locals
-
-                AttributeValue::Exprloc(Expression::new())
-            }
-        }
-        CPlaceInner::VarPair(_, _, _) => {
-            // FIXME implement this
-
-            AttributeValue::Exprloc(Expression::new())
-        }
-        CPlaceInner::VarLane(_, _, _) => {
-            // FIXME implement this
-
-            AttributeValue::Exprloc(Expression::new())
-        }
-        CPlaceInner::Addr(_, _) => {
-            // FIXME implement this (used by arguments and returns)
-
-            AttributeValue::Exprloc(Expression::new())
-
-            // For PointerBase::Stack:
-            //AttributeValue::Exprloc(translate_loc(ValueLoc::Stack(*stack_slot)).unwrap())
-        }
-    }
-}
-
-// Adapted from https://github.com/CraneStation/wasmtime/blob/5a1845b4caf7a5dba8eda1fef05213a532ed4259/crates/debug/src/transform/expression.rs#L59-L137
-fn translate_loc(isa: &dyn TargetIsa, loc: LabelValueLoc) -> Option<Expression> {
-    match loc {
-        LabelValueLoc::Reg(reg) => {
-            let machine_reg = isa.map_regalloc_reg_to_dwarf(reg).unwrap();
-            let mut expr = Expression::new();
-            expr.op_reg(gimli::Register(machine_reg));
-            Some(expr)
-        }
-        LabelValueLoc::SPOffset(offset) => {
-            let mut expr = Expression::new();
-            expr.op_breg(X86_64::RSP, offset);
-            Some(expr)
-        }
     }
 }

--- a/src/debuginfo/mod.rs
+++ b/src/debuginfo/mod.rs
@@ -10,7 +10,9 @@ use crate::prelude::*;
 use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::TargetIsa;
 
-use gimli::write::{Address, AttributeValue, DwarfUnit, LineProgram, LineString, Range, RangeList};
+use gimli::write::{
+    Address, AttributeValue, DwarfUnit, LineProgram, LineString, Range, RangeList, UnitEntryId,
+};
 use gimli::{Encoding, Format, LineEncoding, RunTimeEndian};
 
 pub(crate) use emit::{DebugReloc, DebugRelocName};
@@ -21,6 +23,10 @@ pub(crate) struct DebugContext {
 
     dwarf: DwarfUnit,
     unit_range_list: RangeList,
+}
+
+pub(crate) struct FunctionDebugContext {
+    entry_id: UnitEntryId,
 }
 
 impl DebugContext {
@@ -93,17 +99,7 @@ impl DebugContext {
         DebugContext { endian, dwarf, unit_range_list: RangeList(Vec::new()) }
     }
 
-    pub(crate) fn define_function(
-        &mut self,
-        tcx: TyCtxt<'_>,
-        func_id: FuncId,
-        name: &str,
-        context: &Context,
-        function_span: Span,
-        source_info_set: &indexmap::IndexSet<SourceInfo>,
-    ) {
-        let symbol = func_id.as_u32() as usize;
-
+    pub(crate) fn define_function(&mut self, name: &str) -> FunctionDebugContext {
         // FIXME: add to appropriate scope instead of root
         let scope = self.dwarf.unit.root();
 
@@ -114,15 +110,37 @@ impl DebugContext {
         entry.set(gimli::DW_AT_name, AttributeValue::StringRef(name_id));
         entry.set(gimli::DW_AT_linkage_name, AttributeValue::StringRef(name_id));
 
-        let end =
-            self.create_debug_lines(tcx, symbol, entry_id, context, function_span, source_info_set);
+        FunctionDebugContext { entry_id }
+    }
+}
 
-        self.unit_range_list.0.push(Range::StartLength {
+impl FunctionDebugContext {
+    pub(crate) fn finalize(
+        self,
+        debug_context: &mut DebugContext,
+        tcx: TyCtxt<'_>,
+        func_id: FuncId,
+        context: &Context,
+        function_span: Span,
+        source_info_set: &indexmap::IndexSet<SourceInfo>,
+    ) {
+        let symbol = func_id.as_u32() as usize;
+
+        let end = debug_context.create_debug_lines(
+            tcx,
+            symbol,
+            self.entry_id,
+            context,
+            function_span,
+            source_info_set,
+        );
+
+        debug_context.unit_range_list.0.push(Range::StartLength {
             begin: Address::Symbol { symbol, addend: 0 },
             length: u64::from(end),
         });
 
-        let func_entry = self.dwarf.unit.get_mut(entry_id);
+        let func_entry = debug_context.dwarf.unit.get_mut(self.entry_id);
         // Gdb requires both DW_AT_low_pc and DW_AT_high_pc. Otherwise the DW_TAG_subprogram is skipped.
         func_entry.set(
             gimli::DW_AT_low_pc,

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -120,7 +120,7 @@ fn emit_cgu(
     prof: &SelfProfilerRef,
     name: String,
     module: ObjectModule,
-    debug: Option<DebugContext<'_>>,
+    debug: Option<DebugContext>,
     unwind_context: UnwindContext,
     global_asm_object_file: Option<PathBuf>,
 ) -> Result<ModuleCodegenResult, String> {

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -280,25 +280,20 @@ fn module_codegen(
         cgu.is_primary(),
     );
 
-    let global_asm_object_file = match crate::global_asm::compile_global_asm(
+    let global_asm_object_file = crate::global_asm::compile_global_asm(
         &global_asm_config,
         cgu.name().as_str(),
         &cx.global_asm,
-    ) {
-        Ok(global_asm_object_file) => global_asm_object_file,
-        Err(err) => tcx.sess.fatal(&err),
-    };
+    )?;
 
-    let debug_context = cx.debug_context;
-    let unwind_context = cx.unwind_context;
     tcx.sess.time("write object file", || {
         emit_cgu(
             &global_asm_config.output_filenames,
-            &tcx.sess.prof,
+            &cx.profiler,
             cgu.name().as_str().to_string(),
             module,
-            debug_context,
-            unwind_context,
+            cx.debug_context,
+            cx.unwind_context,
             global_asm_object_file,
         )
     })

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -256,8 +256,9 @@ fn module_codegen(
     for (mono_item, _) in mono_items {
         match mono_item {
             MonoItem::Fn(inst) => {
-                cx.tcx.sess.time("codegen fn", || {
+                tcx.sess.time("codegen fn", || {
                     crate::base::codegen_and_compile_fn(
+                        tcx,
                         &mut cx,
                         &mut cached_context,
                         &mut module,

--- a/src/driver/jit.rs
+++ b/src/driver/jit.rs
@@ -140,7 +140,7 @@ pub(crate) fn run_jit(tcx: TyCtxt<'_>, backend_config: BackendConfig) -> ! {
                         });
                     }
                     CodegenMode::JitLazy => {
-                        codegen_shim(tcx, &mut cached_context, &mut jit_module, inst)
+                        codegen_shim(tcx, &mut cx, &mut cached_context, &mut jit_module, inst)
                     }
                 },
                 MonoItem::Static(def_id) => {
@@ -353,6 +353,7 @@ fn load_imported_symbols_for_jit(
 
 fn codegen_shim<'tcx>(
     tcx: TyCtxt<'tcx>,
+    cx: &mut CodegenCx<'tcx>,
     cached_context: &mut Context,
     module: &mut JITModule,
     inst: Instance<'tcx>,
@@ -403,4 +404,5 @@ fn codegen_shim<'tcx>(
     trampoline_builder.ins().return_(&ret_vals);
 
     module.define_function(func_id, context).unwrap();
+    cx.unwind_context.add_function(func_id, context, module.isa());
 }

--- a/src/driver/jit.rs
+++ b/src/driver/jit.rs
@@ -61,11 +61,11 @@ impl UnsafeMessage {
     }
 }
 
-fn create_jit_module<'tcx>(
-    tcx: TyCtxt<'tcx>,
+fn create_jit_module(
+    tcx: TyCtxt<'_>,
     backend_config: &BackendConfig,
     hotswap: bool,
-) -> (JITModule, CodegenCx<'tcx>) {
+) -> (JITModule, CodegenCx) {
     let crate_info = CrateInfo::new(tcx, "dummy_target_cpu".to_string());
     let imported_symbols = load_imported_symbols_for_jit(tcx.sess, crate_info);
 
@@ -353,7 +353,7 @@ fn load_imported_symbols_for_jit(
 
 fn codegen_shim<'tcx>(
     tcx: TyCtxt<'tcx>,
-    cx: &mut CodegenCx<'tcx>,
+    cx: &mut CodegenCx,
     cached_context: &mut Context,
     module: &mut JITModule,
     inst: Instance<'tcx>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,20 +122,20 @@ impl<F: Fn() -> String> Drop for PrintOnPanic<F> {
 
 /// The codegen context holds any information shared between the codegen of individual functions
 /// inside a single codegen unit with the exception of the Cranelift [`Module`](cranelift_module::Module).
-struct CodegenCx<'tcx> {
+struct CodegenCx {
     profiler: SelfProfilerRef,
     output_filenames: Arc<OutputFilenames>,
     should_write_ir: bool,
     global_asm: String,
     inline_asm_index: Cell<usize>,
-    debug_context: Option<DebugContext<'tcx>>,
+    debug_context: Option<DebugContext>,
     unwind_context: UnwindContext,
     cgu_name: Symbol,
 }
 
-impl<'tcx> CodegenCx<'tcx> {
+impl CodegenCx {
     fn new(
-        tcx: TyCtxt<'tcx>,
+        tcx: TyCtxt<'_>,
         backend_config: BackendConfig,
         isa: &dyn TargetIsa,
         debug_info: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::CodegenResults;
+use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_errors::ErrorGuaranteed;
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
@@ -122,6 +123,7 @@ impl<F: Fn() -> String> Drop for PrintOnPanic<F> {
 /// The codegen context holds any information shared between the codegen of individual functions
 /// inside a single codegen unit with the exception of the Cranelift [`Module`](cranelift_module::Module).
 struct CodegenCx<'tcx> {
+    profiler: SelfProfilerRef,
     output_filenames: Arc<OutputFilenames>,
     should_write_ir: bool,
     global_asm: String,
@@ -149,6 +151,7 @@ impl<'tcx> CodegenCx<'tcx> {
             None
         };
         CodegenCx {
+            profiler: tcx.prof.clone(),
             output_filenames: tcx.output_filenames(()).clone(),
             should_write_ir: crate::pretty_clif::should_write_ir(tcx),
             global_asm: String::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate rustc_driver;
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::CodegenResults;
@@ -121,7 +122,8 @@ impl<F: Fn() -> String> Drop for PrintOnPanic<F> {
 /// The codegen context holds any information shared between the codegen of individual functions
 /// inside a single codegen unit with the exception of the Cranelift [`Module`](cranelift_module::Module).
 struct CodegenCx<'tcx> {
-    tcx: TyCtxt<'tcx>,
+    output_filenames: Arc<OutputFilenames>,
+    should_write_ir: bool,
     global_asm: String,
     inline_asm_index: Cell<usize>,
     debug_context: Option<DebugContext<'tcx>>,
@@ -147,7 +149,8 @@ impl<'tcx> CodegenCx<'tcx> {
             None
         };
         CodegenCx {
-            tcx,
+            output_filenames: tcx.output_filenames(()).clone(),
+            should_write_ir: crate::pretty_clif::should_write_ir(tcx),
             global_asm: String::new(),
             inline_asm_index: Cell::new(0),
             debug_context,

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -1,20 +1,3 @@
 //! Various optimizations specific to cg_clif
 
-use cranelift_codegen::isa::TargetIsa;
-
-use crate::prelude::*;
-
 pub(crate) mod peephole;
-
-pub(crate) fn optimize_function<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    isa: &dyn TargetIsa,
-    instance: Instance<'tcx>,
-    ctx: &mut Context,
-    clif_comments: &mut crate::pretty_clif::CommentWriter,
-) {
-    // FIXME classify optimizations over opt levels once we have more
-
-    crate::pretty_clif::write_clif_file(tcx, "preopt", isa, instance, &ctx.func, &*clif_comments);
-    crate::base::verify_func(tcx, &*clif_comments, &ctx.func);
-}

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -231,16 +231,16 @@ pub(crate) fn write_ir_file(
 
 pub(crate) fn write_clif_file<'tcx>(
     tcx: TyCtxt<'tcx>,
+    symbol_name: &str,
     postfix: &str,
     isa: &dyn cranelift_codegen::isa::TargetIsa,
-    instance: Instance<'tcx>,
     func: &cranelift_codegen::ir::Function,
     mut clif_comments: &CommentWriter,
 ) {
     // FIXME work around filename too long errors
     write_ir_file(
         tcx,
-        || format!("{}.{}.clif", tcx.symbol_name(instance).name, postfix),
+        || format!("{}.{}.clif", symbol_name, postfix),
         |file| {
             let mut clif = String::new();
             cranelift_codegen::write::decorate_function(&mut clif_comments, &mut clif, func)

--- a/src/pretty_clif.rs
+++ b/src/pretty_clif.rs
@@ -62,7 +62,7 @@ use cranelift_codegen::{
 };
 
 use rustc_middle::ty::layout::FnAbiOf;
-use rustc_session::config::OutputType;
+use rustc_session::config::{OutputFilenames, OutputType};
 
 use crate::prelude::*;
 
@@ -205,15 +205,11 @@ pub(crate) fn should_write_ir(tcx: TyCtxt<'_>) -> bool {
 }
 
 pub(crate) fn write_ir_file(
-    tcx: TyCtxt<'_>,
-    name: impl FnOnce() -> String,
+    output_filenames: &OutputFilenames,
+    name: &str,
     write: impl FnOnce(&mut dyn Write) -> std::io::Result<()>,
 ) {
-    if !should_write_ir(tcx) {
-        return;
-    }
-
-    let clif_output_dir = tcx.output_filenames(()).with_extension("clif");
+    let clif_output_dir = output_filenames.with_extension("clif");
 
     match std::fs::create_dir(&clif_output_dir) {
         Ok(()) => {}
@@ -221,16 +217,20 @@ pub(crate) fn write_ir_file(
         res @ Err(_) => res.unwrap(),
     }
 
-    let clif_file_name = clif_output_dir.join(name());
+    let clif_file_name = clif_output_dir.join(name);
 
     let res = std::fs::File::create(clif_file_name).and_then(|mut file| write(&mut file));
     if let Err(err) = res {
-        tcx.sess.warn(&format!("error writing ir file: {}", err));
+        // Using early_warn as no Session is available here
+        rustc_session::early_warn(
+            rustc_session::config::ErrorOutputType::default(),
+            &format!("error writing ir file: {}", err),
+        );
     }
 }
 
-pub(crate) fn write_clif_file<'tcx>(
-    tcx: TyCtxt<'tcx>,
+pub(crate) fn write_clif_file(
+    output_filenames: &OutputFilenames,
     symbol_name: &str,
     postfix: &str,
     isa: &dyn cranelift_codegen::isa::TargetIsa,
@@ -238,27 +238,22 @@ pub(crate) fn write_clif_file<'tcx>(
     mut clif_comments: &CommentWriter,
 ) {
     // FIXME work around filename too long errors
-    write_ir_file(
-        tcx,
-        || format!("{}.{}.clif", symbol_name, postfix),
-        |file| {
-            let mut clif = String::new();
-            cranelift_codegen::write::decorate_function(&mut clif_comments, &mut clif, func)
-                .unwrap();
+    write_ir_file(output_filenames, &format!("{}.{}.clif", symbol_name, postfix), |file| {
+        let mut clif = String::new();
+        cranelift_codegen::write::decorate_function(&mut clif_comments, &mut clif, func).unwrap();
 
-            for flag in isa.flags().iter() {
-                writeln!(file, "set {}", flag)?;
-            }
-            write!(file, "target {}", isa.triple().architecture.to_string())?;
-            for isa_flag in isa.isa_flags().iter() {
-                write!(file, " {}", isa_flag)?;
-            }
-            writeln!(file, "\n")?;
-            writeln!(file)?;
-            file.write_all(clif.as_bytes())?;
-            Ok(())
-        },
-    );
+        for flag in isa.flags().iter() {
+            writeln!(file, "set {}", flag)?;
+        }
+        write!(file, "target {}", isa.triple().architecture.to_string())?;
+        for isa_flag in isa.isa_flags().iter() {
+            write!(file, " {}", isa_flag)?;
+        }
+        writeln!(file, "\n")?;
+        writeln!(file)?;
+        file.write_all(clif.as_bytes())?;
+        Ok(())
+    });
 }
 
 impl fmt::Debug for FunctionCx<'_, '_, '_> {


### PR DESCRIPTION
This PR contains a bunch of refactorings to remove dependencies on TyCtxt and Session for various functions that will in the future be called on background threads as those types are only available on the main thread. Most of this PR concerns the debuginfo generation code, but there are also a couple of refactorings to other code.

Part of https://github.com/bjorn3/rustc_codegen_cranelift/issues/652

See https://github.com/bjorn3/rustc_codegen_cranelift/pull/1264 for the previous PR in this series.