### PR TITLE
Use native scalar `fma` instruction

### DIFF
--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -303,6 +303,12 @@ fn codegen_float_intrinsic_call<'tcx>(
 
     let layout = fx.layout_of(ty);
     let res = match intrinsic {
+        sym::fmaf32 | sym::fmaf64 => {
+            let a = args[0].load_scalar(fx);
+            let b = args[1].load_scalar(fx);
+            let c = args[2].load_scalar(fx);
+            CValue::by_val(fx.bcx.ins().fma(a, b, c), layout)
+        }
         sym::copysignf32 | sym::copysignf64 => {
             let a = args[0].load_scalar(fx);
             let b = args[1].load_scalar(fx);


### PR DESCRIPTION
Cranelift 0.87 now supports [lowering `fma` as a libcall on x86](https://github.com/bytecodealliance/wasmtime/commit/709716bb8e6adaf7e65f3497168af23ce0cf09ef).
With 0.88 enabling the native x86 instruction under the `has_fma` flag.

aarch64 and s390x already support this as a native instruction, so it's nice that we emit it for those.

We can't lower the SIMD version using the `fma` instruction since the lowering can fail if the x86 `has_fma` flag is not enabled. Cranelift doesn't yet know how to fallback for these cases.

We need to wait for the 0.87 release before merging this.