### PR TITLE
prevent unexpected formatting by rustfmt

### DIFF
--- a/y.rs
+++ b/y.rs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#![deny(unsafe_code)] /*This line is ignored by bash
+#![rustfmt::skip] /*This line is ignored by bash
 # This block is ignored by rustc
 set -e
 echo "[BUILD] y.rs" 1>&2

--- a/y.rs
+++ b/y.rs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#![rustfmt::skip] /*This line is ignored by bash
+#[rustfmt::skip] /*This line is ignored by bash
 # This block is ignored by rustc
 set -e
 echo "[BUILD] y.rs" 1>&2


### PR DESCRIPTION
While open this file in an editor which is configured with things like autoformat, lines between `set -e` and `*/` will be formatted into typical rust comments.