### PR TITLE
Support compiling codegen units in parallel

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -11,7 +11,7 @@ use crate::debuginfo::FunctionDebugContext;
 use crate::prelude::*;
 use crate::pretty_clif::CommentWriter;
 
-struct CodegenedFunction {
+pub(crate) struct CodegenedFunction {
     symbol_name: String,
     func_id: FuncId,
     func: Function,
@@ -19,6 +19,7 @@ struct CodegenedFunction {
     func_debug_cx: Option<FunctionDebugContext>,
 }
 
+#[cfg_attr(not(feature = "jit"), allow(dead_code))]
 pub(crate) fn codegen_and_compile_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
     cx: &mut crate::CodegenCx,
@@ -35,7 +36,7 @@ pub(crate) fn codegen_and_compile_fn<'tcx>(
     compile_fn(cx, cached_context, module, codegened_func);
 }
 
-fn codegen_fn<'tcx>(
+pub(crate) fn codegen_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
     cx: &mut crate::CodegenCx,
     cached_func: Function,
@@ -135,7 +136,7 @@ fn codegen_fn<'tcx>(
     CodegenedFunction { symbol_name, func_id, func, clif_comments, func_debug_cx }
 }
 
-fn compile_fn(
+pub(crate) fn compile_fn(
     cx: &mut crate::CodegenCx,
     cached_context: &mut Context,
     module: &mut dyn Module,

--- a/src/base.rs
+++ b/src/base.rs
@@ -5,15 +5,14 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::layout::FnAbiOf;
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::SymbolName;
 
 use crate::constant::ConstantCx;
 use crate::debuginfo::FunctionDebugContext;
 use crate::prelude::*;
 use crate::pretty_clif::CommentWriter;
 
-struct CodegenedFunction<'tcx> {
-    symbol_name: SymbolName<'tcx>,
+struct CodegenedFunction {
+    symbol_name: String,
     func_id: FuncId,
     func: Function,
     clif_comments: CommentWriter,
@@ -42,7 +41,7 @@ fn codegen_fn<'tcx>(
     cached_func: Function,
     module: &mut dyn Module,
     instance: Instance<'tcx>,
-) -> CodegenedFunction<'tcx> {
+) -> CodegenedFunction {
     debug_assert!(!instance.substs.needs_infer());
 
     let mir = tcx.instance_mir(instance.def);
@@ -56,9 +55,9 @@ fn codegen_fn<'tcx>(
     });
 
     // Declare function
-    let symbol_name = tcx.symbol_name(instance);
+    let symbol_name = tcx.symbol_name(instance).name.to_string();
     let sig = get_function_sig(tcx, module.isa().triple(), instance);
-    let func_id = module.declare_function(symbol_name.name, Linkage::Local, &sig).unwrap();
+    let func_id = module.declare_function(&symbol_name, Linkage::Local, &sig).unwrap();
 
     // Make the FunctionBuilder
     let mut func_ctx = FunctionBuilderContext::new();
@@ -81,7 +80,7 @@ fn codegen_fn<'tcx>(
     let clif_comments = crate::pretty_clif::CommentWriter::new(tcx, instance);
 
     let func_debug_cx = if let Some(debug_context) = &mut cx.debug_context {
-        Some(debug_context.define_function(tcx, symbol_name.name, mir.span))
+        Some(debug_context.define_function(tcx, &symbol_name, mir.span))
     } else {
         None
     };
@@ -113,6 +112,7 @@ fn codegen_fn<'tcx>(
     tcx.sess.time("codegen clif ir", || codegen_fn_body(&mut fx, start_block));
 
     // Recover all necessary data from fx, before accessing func will prevent future access to it.
+    let symbol_name = fx.symbol_name;
     let clif_comments = fx.clif_comments;
     let func_debug_cx = fx.func_debug_cx;
 
@@ -121,7 +121,7 @@ fn codegen_fn<'tcx>(
     if cx.should_write_ir {
         crate::pretty_clif::write_clif_file(
             tcx.output_filenames(()),
-            symbol_name.name,
+            &symbol_name,
             "unopt",
             module.isa(),
             &func,
@@ -135,11 +135,11 @@ fn codegen_fn<'tcx>(
     CodegenedFunction { symbol_name, func_id, func, clif_comments, func_debug_cx }
 }
 
-fn compile_fn<'tcx>(
+fn compile_fn(
     cx: &mut crate::CodegenCx,
     cached_context: &mut Context,
     module: &mut dyn Module,
-    codegened_func: CodegenedFunction<'tcx>,
+    codegened_func: CodegenedFunction,
 ) {
     let clif_comments = codegened_func.clif_comments;
 
@@ -195,7 +195,7 @@ fn compile_fn<'tcx>(
         // Write optimized function to file for debugging
         crate::pretty_clif::write_clif_file(
             &cx.output_filenames,
-            codegened_func.symbol_name.name,
+            &codegened_func.symbol_name,
             "opt",
             module.isa(),
             &context.func,
@@ -205,7 +205,7 @@ fn compile_fn<'tcx>(
         if let Some(disasm) = &context.compiled_code().unwrap().disasm {
             crate::pretty_clif::write_ir_file(
                 &cx.output_filenames,
-                &format!("{}.vcode", codegened_func.symbol_name.name),
+                &format!("{}.vcode", codegened_func.symbol_name),
                 |file| file.write_all(disasm.as_bytes()),
             )
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,6 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOfHelpers,
 };
-use rustc_middle::ty::SymbolName;
 use rustc_span::SourceFile;
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{Integer, Primitive};
@@ -246,7 +245,7 @@ pub(crate) struct FunctionCx<'m, 'clif, 'tcx: 'm> {
     pub(crate) func_debug_cx: Option<FunctionDebugContext>,
 
     pub(crate) instance: Instance<'tcx>,
-    pub(crate) symbol_name: SymbolName<'tcx>,
+    pub(crate) symbol_name: String,
     pub(crate) mir: &'tcx Body<'tcx>,
     pub(crate) fn_abi: Option<&'tcx FnAbi<'tcx, Ty<'tcx>>>,
 

--- a/src/concurrency_limiter.rs
+++ b/src/concurrency_limiter.rs
@@ -4,6 +4,8 @@ use rustc_session::Session;
 
 use jobserver::HelperThread;
 
+// FIXME don't panic when a worker thread panics
+
 pub(super) struct ConcurrencyLimiter {
     helper_thread: Option<HelperThread>,
     state: Arc<Mutex<state::ConcurrencyLimiterState>>,

--- a/src/concurrency_limiter.rs
+++ b/src/concurrency_limiter.rs
@@ -1,0 +1,153 @@
+use std::sync::{Arc, Condvar, Mutex};
+
+use rustc_session::Session;
+
+use jobserver::HelperThread;
+
+pub(super) struct ConcurrencyLimiter {
+    helper_thread: Option<HelperThread>,
+    state: Arc<Mutex<state::ConcurrencyLimiterState>>,
+    available_token_condvar: Arc<Condvar>,
+}
+
+impl ConcurrencyLimiter {
+    pub(super) fn new(sess: &Session, pending_jobs: usize) -> Self {
+        let state = Arc::new(Mutex::new(state::ConcurrencyLimiterState::new(pending_jobs)));
+        let available_token_condvar = Arc::new(Condvar::new());
+
+        let state_helper = state.clone();
+        let available_token_condvar_helper = available_token_condvar.clone();
+        let helper_thread = sess
+            .jobserver
+            .clone()
+            .into_helper_thread(move |token| {
+                let mut state = state_helper.lock().unwrap();
+                state.add_new_token(token.unwrap());
+                available_token_condvar_helper.notify_one();
+            })
+            .unwrap();
+        ConcurrencyLimiter {
+            helper_thread: Some(helper_thread),
+            state,
+            available_token_condvar: Arc::new(Condvar::new()),
+        }
+    }
+
+    pub(super) fn acquire(&mut self) -> ConcurrencyLimiterToken {
+        let mut state = self.state.lock().unwrap();
+        loop {
+            state.assert_invariants();
+
+            if state.try_start_job() {
+                return ConcurrencyLimiterToken {
+                    state: self.state.clone(),
+                    available_token_condvar: self.available_token_condvar.clone(),
+                };
+            }
+
+            self.helper_thread.as_mut().unwrap().request_token();
+            state = self.available_token_condvar.wait(state).unwrap();
+        }
+    }
+}
+
+impl Drop for ConcurrencyLimiter {
+    fn drop(&mut self) {
+        //
+        self.helper_thread.take();
+
+        // Assert that all jobs have finished
+        let state = Mutex::get_mut(Arc::get_mut(&mut self.state).unwrap()).unwrap();
+        state.assert_done();
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ConcurrencyLimiterToken {
+    state: Arc<Mutex<state::ConcurrencyLimiterState>>,
+    available_token_condvar: Arc<Condvar>,
+}
+
+impl Drop for ConcurrencyLimiterToken {
+    fn drop(&mut self) {
+        let mut state = self.state.lock().unwrap();
+        state.job_finished();
+        self.available_token_condvar.notify_one();
+    }
+}
+
+mod state {
+    use jobserver::Acquired;
+
+    #[derive(Debug)]
+    pub(super) struct ConcurrencyLimiterState {
+        pending_jobs: usize,
+        active_jobs: usize,
+
+        // None is used to represent the implicit token, Some to represent explicit tokens
+        tokens: Vec<Option<Acquired>>,
+    }
+
+    impl ConcurrencyLimiterState {
+        pub(super) fn new(pending_jobs: usize) -> Self {
+            ConcurrencyLimiterState { pending_jobs, active_jobs: 0, tokens: vec![None] }
+        }
+
+        pub(super) fn assert_invariants(&self) {
+            // There must be no excess active jobs
+            assert!(self.active_jobs <= self.pending_jobs);
+
+            // There may not be more active jobs than there are tokens
+            assert!(self.active_jobs <= self.tokens.len());
+        }
+
+        pub(super) fn assert_done(&self) {
+            assert_eq!(self.pending_jobs, 0);
+            assert_eq!(self.active_jobs, 0);
+        }
+
+        pub(super) fn add_new_token(&mut self, token: Acquired) {
+            self.tokens.push(Some(token));
+            self.drop_excess_capacity();
+        }
+
+        pub(super) fn try_start_job(&mut self) -> bool {
+            if self.active_jobs < self.tokens.len() {
+                // Using existing token
+                self.job_started();
+                return true;
+            }
+
+            false
+        }
+
+        pub(super) fn job_started(&mut self) {
+            self.assert_invariants();
+            self.active_jobs += 1;
+            self.drop_excess_capacity();
+            self.assert_invariants();
+        }
+
+        pub(super) fn job_finished(&mut self) {
+            self.assert_invariants();
+            self.pending_jobs -= 1;
+            self.active_jobs -= 1;
+            self.assert_invariants();
+            self.drop_excess_capacity();
+            self.assert_invariants();
+        }
+
+        fn drop_excess_capacity(&mut self) {
+            self.assert_invariants();
+            if self.active_jobs == self.pending_jobs {
+                // Drop all excess tokens
+                self.tokens.truncate(std::cmp::max(self.active_jobs, 1));
+            } else {
+                // Keep some excess tokens to satisfy requests faster
+                const MAX_EXTRA_CAPACITY: usize = 2;
+                self.tokens.truncate(std::cmp::max(self.active_jobs + MAX_EXTRA_CAPACITY, 1));
+            }
+            self.assert_invariants();
+        }
+    }
+}

--- a/src/concurrency_limiter.rs
+++ b/src/concurrency_limiter.rs
@@ -152,14 +152,14 @@ mod state {
 
         fn drop_excess_capacity(&mut self) {
             self.assert_invariants();
-            if self.active_jobs == self.pending_jobs {
-                // Drop all excess tokens
-                self.tokens.truncate(std::cmp::max(self.active_jobs, 1));
-            } else {
-                // Keep some excess tokens to satisfy requests faster
-                const MAX_EXTRA_CAPACITY: usize = 2;
-                self.tokens.truncate(std::cmp::max(self.active_jobs + MAX_EXTRA_CAPACITY, 1));
-            }
+
+            // Drop all tokens that can never be used anymore
+            self.tokens.truncate(std::cmp::max(self.pending_jobs, 1));
+
+            // Keep some excess tokens to satisfy requests faster
+            const MAX_EXTRA_CAPACITY: usize = 2;
+            self.tokens.truncate(std::cmp::max(self.active_jobs + MAX_EXTRA_CAPACITY, 1));
+
             self.assert_invariants();
         }
     }

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -391,6 +391,7 @@ pub(crate) fn run_aot(
                     }
                     CguReuse::PreLto => unreachable!(),
                     CguReuse::PostLto => {
+                        concurrency_limiter.job_already_done();
                         OngoingModuleCodegen::Sync(reuse_workproduct_for_cgu(tcx, &*cgu))
                     }
                 }

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -271,18 +271,14 @@ fn module_codegen(
         cgu_name,
     );
     super::predefine_mono_items(tcx, &mut module, &mono_items);
-    let mut cached_context = Context::new();
+    let mut codegened_functions = vec![];
     for (mono_item, _) in mono_items {
         match mono_item {
             MonoItem::Fn(inst) => {
                 tcx.sess.time("codegen fn", || {
-                    crate::base::codegen_and_compile_fn(
-                        tcx,
-                        &mut cx,
-                        &mut cached_context,
-                        &mut module,
-                        inst,
-                    )
+                    let codegened_function =
+                        crate::base::codegen_fn(tcx, &mut cx, Function::new(), &mut module, inst);
+                    codegened_functions.push(codegened_function);
                 });
             }
             MonoItem::Static(def_id) => crate::constant::codegen_static(tcx, &mut module, def_id),
@@ -302,6 +298,11 @@ fn module_codegen(
     let cgu_name = cgu.name().as_str().to_owned();
 
     OngoingModuleCodegen::Async(std::thread::spawn(move || {
+        let mut cached_context = Context::new();
+        for codegened_func in codegened_functions {
+            crate::base::compile_fn(&mut cx, &mut cached_context, &mut module, codegened_func);
+        }
+
         let global_asm_object_file =
             crate::global_asm::compile_global_asm(&global_asm_config, &cgu_name, &cx.global_asm)?;
 

--- a/src/driver/aot.rs
+++ b/src/driver/aot.rs
@@ -373,10 +373,10 @@ pub(crate) fn run_aot(
                             )
                             .0
                     }
-                    CguReuse::PreLto => {
+                    CguReuse::PreLto => unreachable!(),
+                    CguReuse::PostLto => {
                         OngoingModuleCodegen::Sync(reuse_workproduct_for_cgu(tcx, &*cgu))
                     }
-                    CguReuse::PostLto => unreachable!(),
                 }
             })
             .collect::<Vec<_>>()
@@ -485,5 +485,5 @@ fn determine_cgu_reuse<'tcx>(tcx: TyCtxt<'tcx>, cgu: &CodegenUnit<'tcx>) -> CguR
         cgu.name()
     );
 
-    if tcx.try_mark_green(&dep_node) { CguReuse::PreLto } else { CguReuse::No }
+    if tcx.try_mark_green(&dep_node) { CguReuse::PostLto } else { CguReuse::No }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(unused_lifetimes)]
 #![warn(unreachable_pub)]
 
+extern crate jobserver;
 #[macro_use]
 extern crate rustc_middle;
 extern crate rustc_ast;
@@ -53,6 +54,7 @@ mod cast;
 mod codegen_i128;
 mod common;
 mod compiler_builtins;
+mod concurrency_limiter;
 mod config;
 mod constant;
 mod debuginfo;


### PR DESCRIPTION
With this on machines with many cores cg_llvm no longer has a perf advantage over cg_clif on the simple-raytracer benchmark:

```
$ hyperfine --prepare "cargo clean" "cargo build" "../build/cargo-clif build"
Benchmark 1: cargo build
  Time (mean ± σ):      6.782 s ±  0.014 s    [User: 23.918 s, System: 4.269 s]
  Range (min … max):    6.755 s …  6.800 s    10 runs
 
Benchmark 2: ../build/cargo-clif build
  Time (mean ± σ):      6.505 s ±  0.017 s    [User: 16.604 s, System: 3.640 s]
  Range (min … max):    6.484 s …  6.540 s    10 runs
 
Summary
  '../build/cargo-clif build' ran
    1.04 ± 0.00 times faster than 'cargo build'
```

And even on my personal laptop there is a non-trivial perf improvement (~35% perf benefit of cg_clif over cg_llvm as opposed to ~20% previously):

```
Benchmark 1: cargo build
  Time (mean ± σ):     16.985 s ±  0.487 s    [User: 48.250 s, System: 4.623 s]
  Range (min … max):   16.692 s … 18.339 s    10 runs
 
Benchmark 2: ~/Projects/cg_clif2/build/cargo-clif build
  Time (mean ± σ):     12.517 s ±  0.065 s    [User: 29.892 s, System: 4.536 s]
  Range (min … max):   12.438 s … 12.642 s    10 runs
 
Summary
  '~/Projects/cg_clif2/build/cargo-clif build' ran
    1.36 ± 0.04 times faster than 'cargo build'
```

On the rustc perf suite there are now only a couple of wall time regressions compared to cg_llvm as opposed to almost all.

<details><summary>Wall time on the rustc perf suite when compared to cg_llvm.</summary>

![image](https://user-images.githubusercontent.com/17426603/186444984-05a1362a-60c8-486f-bdcd-01bcdab87e52.png)

</details>

The jobserver handling could probably be finetuned for a bit more performance, but as I have been struggling with getting it to work correctly at all for almost a week, I'm going to leave that for now.


Fixes https://github.com/bjorn3/rustc_codegen_cranelift/issues/652