### PR TITLE
Update `target-lexicon` to fix new targets parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "version_check"


### PR DESCRIPTION
This pulls in https://github.com/bytecodealliance/target-lexicon/pull/82
Noticed that `./x.py c` fails in Rust repo when using `*-gnullvm` targets because of `target-lexicon` and it could be easily fixed. Haven't tested how many further changes will be required,