### PR TITLE
Many build system improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,10 +91,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-s390x-linux-gnu qemu-user
 
-    - name: Windows setup
-      if: matrix.os == 'windows-latest'
-      run: git config --global core.autocrlf false
-
     - name: Use sparse cargo registry
       run: |
         cat >> ~/.cargo/config.toml <<EOF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,14 +62,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Cache cargo registry and index
-      uses: actions/cache@v3
-      with:
-        path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-        key: ${{ runner.os }}-${{ matrix.env.TARGET_TRIPLE }}-cargo-registry-and-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Cache cargo target dir
       uses: actions/cache@v3
       with:
@@ -102,6 +94,13 @@ jobs:
     - name: Windows setup
       if: matrix.os == 'windows-latest'
       run: git config --global core.autocrlf false
+
+    - name: Use sparse cargo registry
+      run: |
+        cat >> ~/.cargo/config.toml <<EOF
+        [unstable]
+        sparse-registry = true
+        EOF
 
     - name: Prepare dependencies
       run: ./y.rs prepare

--- a/.github/workflows/nightly-cranelift.yml
+++ b/.github/workflows/nightly-cranelift.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Use sparse cargo registry
+      run: |
+        cat >> ~/.cargo/config.toml <<EOF
+        [unstable]
+        sparse-registry = true
+        EOF
+
     - name: Prepare dependencies
       run: |
         git config --global user.email "user@example.com"

--- a/.github/workflows/nightly-cranelift.yml
+++ b/.github/workflows/nightly-cranelift.yml
@@ -21,10 +21,7 @@ jobs:
         EOF
 
     - name: Prepare dependencies
-      run: |
-        git config --global user.email "user@example.com"
-        git config --global user.name "User"
-        ./y.rs prepare
+      run: ./y.rs prepare
 
     - name: Patch Cranelift
       run: |

--- a/.github/workflows/nightly-cranelift.yml
+++ b/.github/workflows/nightly-cranelift.yml
@@ -36,6 +36,8 @@ jobs:
 
         cat Cargo.toml
 
+        cargo fetch
+
     - name: Build without unstable features
       # This is the config rust-lang/rust uses for builds
       run: ./y.rs build --no-unstable-features

--- a/.github/workflows/rustc.yml
+++ b/.github/workflows/rustc.yml
@@ -24,10 +24,7 @@ jobs:
         EOF
 
     - name: Prepare dependencies
-      run: |
-        git config --global user.email "user@example.com"
-        git config --global user.name "User"
-        ./y.rs prepare
+      run: ./y.rs prepare
 
     - name: Test
       run: ./scripts/test_bootstrap.sh
@@ -51,10 +48,7 @@ jobs:
         EOF
 
     - name: Prepare dependencies
-      run: |
-        git config --global user.email "user@example.com"
-        git config --global user.name "User"
-        ./y.rs prepare
+      run: ./y.rs prepare
 
     - name: Test
       run: ./scripts/test_rustc_tests.sh

--- a/.github/workflows/rustc.yml
+++ b/.github/workflows/rustc.yml
@@ -10,19 +10,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Cache cargo registry and index
-      uses: actions/cache@v3
-      with:
-        path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-        key: ${{ runner.os }}-cargo-registry-and-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Cache cargo target dir
       uses: actions/cache@v3
       with:
         path: build/cg_clif
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('rust-toolchain', '**/Cargo.lock') }}
+
+    - name: Use sparse cargo registry
+      run: |
+        cat >> ~/.cargo/config.toml <<EOF
+        [unstable]
+        sparse-registry = true
+        EOF
 
     - name: Prepare dependencies
       run: |
@@ -38,19 +37,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Cache cargo registry and index
-      uses: actions/cache@v3
-      with:
-        path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-        key: ${{ runner.os }}-cargo-registry-and-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Cache cargo target dir
       uses: actions/cache@v3
       with:
         path: build/cg_clif
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('rust-toolchain', '**/Cargo.lock') }}
+
+    - name: Use sparse cargo registry
+      run: |
+        cat >> ~/.cargo/config.toml <<EOF
+        [unstable]
+        sparse-registry = true
+        EOF
 
     - name: Prepare dependencies
       run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+    "editor.formatOnSave": true,
+
     // source for rustc_* is not included in the rust-src component; disable the errors about this
     "rust-analyzer.diagnostics.disabled": ["unresolved-extern-crate", "unresolved-macro-call"],
     "rust-analyzer.imports.granularity.enforce": true,

--- a/Readme.md
+++ b/Readme.md
@@ -8,9 +8,9 @@ If not please open an issue.
 ## Building and testing
 
 ```bash
-$ git clone https://github.com/bjorn3/rustc_codegen_cranelift.git
+$ git clone https://github.com/bjorn3/rustc_codegen_cranelift
 $ cd rustc_codegen_cranelift
-$ ./y.rs prepare # download and patch sysroot src and install hyperfine for benchmarking
+$ ./y.rs prepare
 $ ./y.rs build
 ```
 
@@ -20,13 +20,12 @@ To run the test suite replace the last command with:
 $ ./test.sh
 ```
 
-This will implicitly build cg_clif too. Both `y.rs build` and `test.sh` accept a `--debug` argument to
-build in debug mode.
+For more docs on how to build and test see [build_system/usage.txt](build_system/usage.txt) or the help message of `./y.rs`.
 
-Alternatively you can download a pre built version from [GHA]. It is listed in the artifacts section
+Alternatively you can download a pre built version from [Github Actions]. It is listed in the artifacts section
 of workflow runs. Unfortunately due to GHA restrictions you need to be logged in to access it.
 
-[GHA]: https://github.com/bjorn3/rustc_codegen_cranelift/actions?query=branch%3Amaster+event%3Apush+is%3Asuccess
+[Github Actions]: https://github.com/bjorn3/rustc_codegen_cranelift/actions?query=branch%3Amaster+event%3Apush+is%3Asuccess
 
 ## Usage
 

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -10,7 +10,7 @@ use super::SysrootKind;
 pub(crate) static ABI_CAFE_REPO: GitRepo =
     GitRepo::github("Gankra", "abi-cafe", "4c6dc8c9c687e2b3a760ff2176ce236872b37212", "abi-cafe");
 
-static ABI_CAFE: CargoProject = CargoProject::new(&ABI_CAFE_REPO.source_dir(), "abi_cafe");
+pub(crate) static ABI_CAFE: CargoProject = CargoProject::new(&ABI_CAFE_REPO.source_dir(), "abi_cafe");
 
 pub(crate) fn run(
     channel: &str,

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -10,7 +10,8 @@ use super::SysrootKind;
 pub(crate) static ABI_CAFE_REPO: GitRepo =
     GitRepo::github("Gankra", "abi-cafe", "4c6dc8c9c687e2b3a760ff2176ce236872b37212", "abi-cafe");
 
-pub(crate) static ABI_CAFE: CargoProject = CargoProject::new(&ABI_CAFE_REPO.source_dir(), "abi_cafe");
+pub(crate) static ABI_CAFE: CargoProject =
+    CargoProject::new(&ABI_CAFE_REPO.source_dir(), "abi_cafe");
 
 pub(crate) fn run(
     channel: &str,

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -17,16 +17,10 @@ pub(crate) fn run(
     sysroot_kind: SysrootKind,
     dirs: &Dirs,
     cg_clif_dylib: &Path,
-    host_triple: &str,
-    target_triple: &str,
+    host_compiler: &Compiler,
 ) {
     if !config::get_bool("testsuite.abi-cafe") {
         eprintln!("[SKIP] abi-cafe");
-        return;
-    }
-
-    if host_triple != target_triple {
-        eprintln!("[SKIP] abi-cafe (cross-compilation not supported)");
         return;
     }
 
@@ -36,15 +30,15 @@ pub(crate) fn run(
         channel,
         sysroot_kind,
         cg_clif_dylib,
-        host_triple,
-        target_triple,
+        host_compiler,
+        &host_compiler.triple,
     );
 
     eprintln!("Running abi-cafe");
 
     let pairs = ["rustc_calls_cgclif", "cgclif_calls_rustc", "cgclif_calls_cc", "cc_calls_cgclif"];
 
-    let mut cmd = ABI_CAFE.run(&Compiler::host(), dirs);
+    let mut cmd = ABI_CAFE.run(host_compiler, dirs);
     cmd.arg("--");
     cmd.arg("--pairs");
     cmd.args(pairs);

--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -21,11 +21,11 @@ pub(crate) static SIMPLE_RAYTRACER_LLVM: CargoProject =
 pub(crate) static SIMPLE_RAYTRACER: CargoProject =
     CargoProject::new(&SIMPLE_RAYTRACER_REPO.source_dir(), "simple_raytracer");
 
-pub(crate) fn benchmark(dirs: &Dirs) {
-    benchmark_simple_raytracer(dirs);
+pub(crate) fn benchmark(dirs: &Dirs, host_compiler: &Compiler) {
+    benchmark_simple_raytracer(dirs, host_compiler);
 }
 
-fn benchmark_simple_raytracer(dirs: &Dirs) {
+fn benchmark_simple_raytracer(dirs: &Dirs, host_compiler: &Compiler) {
     if std::process::Command::new("hyperfine").output().is_err() {
         eprintln!("Hyperfine not installed");
         eprintln!("Hint: Try `cargo install hyperfine` to install hyperfine");
@@ -33,8 +33,7 @@ fn benchmark_simple_raytracer(dirs: &Dirs) {
     }
 
     eprintln!("[LLVM BUILD] simple-raytracer");
-    let host_compiler = Compiler::host();
-    let build_cmd = SIMPLE_RAYTRACER_LLVM.build(&host_compiler, dirs);
+    let build_cmd = SIMPLE_RAYTRACER_LLVM.build(host_compiler, dirs);
     spawn_and_wait(build_cmd);
     fs::copy(
         SIMPLE_RAYTRACER_LLVM

--- a/build_system/build_backend.rs
+++ b/build_system/build_backend.rs
@@ -5,7 +5,7 @@ use super::path::{Dirs, RelPath};
 use super::rustc_info::get_file_name;
 use super::utils::{is_ci, CargoProject, Compiler};
 
-static CG_CLIF: CargoProject = CargoProject::new(&RelPath::SOURCE, "cg_clif");
+pub(crate) static CG_CLIF: CargoProject = CargoProject::new(&RelPath::SOURCE, "cg_clif");
 
 pub(crate) fn build_backend(
     dirs: &Dirs,

--- a/build_system/build_backend.rs
+++ b/build_system/build_backend.rs
@@ -10,10 +10,10 @@ static CG_CLIF: CargoProject = CargoProject::new(&RelPath::SOURCE, "cg_clif");
 pub(crate) fn build_backend(
     dirs: &Dirs,
     channel: &str,
-    host_triple: &str,
+    host_compiler: &Compiler,
     use_unstable_features: bool,
 ) -> PathBuf {
-    let mut cmd = CG_CLIF.build(&Compiler::host(), dirs);
+    let mut cmd = CG_CLIF.build(&host_compiler, dirs);
 
     cmd.env("CARGO_BUILD_INCREMENTAL", "true"); // Force incr comp even in release mode
 
@@ -48,7 +48,7 @@ pub(crate) fn build_backend(
 
     CG_CLIF
         .target_dir(dirs)
-        .join(host_triple)
+        .join(&host_compiler.triple)
         .join(channel)
         .join(get_file_name("rustc_codegen_cranelift", "dylib"))
 }

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -153,7 +153,8 @@ pub(crate) static ORIG_BUILD_SYSROOT: RelPath = RelPath::SOURCE.join("build_sysr
 pub(crate) static BUILD_SYSROOT: RelPath = RelPath::DOWNLOAD.join("sysroot");
 pub(crate) static SYSROOT_RUSTC_VERSION: RelPath = BUILD_SYSROOT.join("rustc_version");
 pub(crate) static SYSROOT_SRC: RelPath = BUILD_SYSROOT.join("sysroot_src");
-pub(crate) static STANDARD_LIBRARY: CargoProject = CargoProject::new(&BUILD_SYSROOT, "build_sysroot");
+pub(crate) static STANDARD_LIBRARY: CargoProject =
+    CargoProject::new(&BUILD_SYSROOT, "build_sysroot");
 
 fn build_clif_sysroot_for_triple(
     dirs: &Dirs,

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -17,7 +17,7 @@ pub(crate) fn build_sysroot(
     channel: &str,
     sysroot_kind: SysrootKind,
     cg_clif_dylib_src: &Path,
-    host_triple: &str,
+    host_compiler: &Compiler,
     target_triple: &str,
 ) {
     eprintln!("[BUILD] sysroot {:?}", sysroot_kind);
@@ -53,7 +53,7 @@ pub(crate) fn build_sysroot(
 
     let default_sysroot = super::rustc_info::get_default_sysroot();
 
-    let host_rustlib_lib = RUSTLIB_DIR.to_path(dirs).join(host_triple).join("lib");
+    let host_rustlib_lib = RUSTLIB_DIR.to_path(dirs).join(&host_compiler.triple).join("lib");
     let target_rustlib_lib = RUSTLIB_DIR.to_path(dirs).join(target_triple).join("lib");
     fs::create_dir_all(&host_rustlib_lib).unwrap();
     fs::create_dir_all(&target_rustlib_lib).unwrap();
@@ -83,7 +83,7 @@ pub(crate) fn build_sysroot(
         SysrootKind::None => {} // Nothing to do
         SysrootKind::Llvm => {
             for file in fs::read_dir(
-                default_sysroot.join("lib").join("rustlib").join(host_triple).join("lib"),
+                default_sysroot.join("lib").join("rustlib").join(&host_compiler.triple).join("lib"),
             )
             .unwrap()
             {
@@ -103,7 +103,7 @@ pub(crate) fn build_sysroot(
                 try_hard_link(&file, host_rustlib_lib.join(file.file_name().unwrap()));
             }
 
-            if target_triple != host_triple {
+            if target_triple != host_compiler.triple {
                 for file in fs::read_dir(
                     default_sysroot.join("lib").join("rustlib").join(target_triple).join("lib"),
                 )
@@ -115,9 +115,15 @@ pub(crate) fn build_sysroot(
             }
         }
         SysrootKind::Clif => {
-            build_clif_sysroot_for_triple(dirs, channel, host_triple, &cg_clif_dylib_path, None);
+            build_clif_sysroot_for_triple(
+                dirs,
+                channel,
+                host_compiler.clone(),
+                &cg_clif_dylib_path,
+                None,
+            );
 
-            if host_triple != target_triple {
+            if host_compiler.triple != target_triple {
                 // When cross-compiling it is often necessary to manually pick the right linker
                 let linker = match target_triple {
                     "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu-gcc"),
@@ -127,7 +133,11 @@ pub(crate) fn build_sysroot(
                 build_clif_sysroot_for_triple(
                     dirs,
                     channel,
-                    target_triple,
+                    {
+                        let mut target_compiler = host_compiler.clone();
+                        target_compiler.triple = target_triple.to_owned();
+                        target_compiler
+                    },
                     &cg_clif_dylib_path,
                     linker,
                 );
@@ -155,7 +165,7 @@ static STANDARD_LIBRARY: CargoProject = CargoProject::new(&BUILD_SYSROOT, "build
 fn build_clif_sysroot_for_triple(
     dirs: &Dirs,
     channel: &str,
-    triple: &str,
+    mut compiler: Compiler,
     cg_clif_dylib_path: &Path,
     linker: Option<&str>,
 ) {
@@ -177,7 +187,7 @@ fn build_clif_sysroot_for_triple(
         }
     }
 
-    let build_dir = STANDARD_LIBRARY.target_dir(dirs).join(triple).join(channel);
+    let build_dir = STANDARD_LIBRARY.target_dir(dirs).join(&compiler.triple).join(channel);
 
     if !super::config::get_bool("keep_sysroot") {
         // Cleanup the deps dir, but keep build scripts and the incremental cache for faster
@@ -188,7 +198,7 @@ fn build_clif_sysroot_for_triple(
     }
 
     // Build sysroot
-    let mut rustflags = "-Zforce-unstable-if-unmarked -Cpanic=abort".to_string();
+    let mut rustflags = " -Zforce-unstable-if-unmarked -Cpanic=abort".to_string();
     rustflags.push_str(&format!(" -Zcodegen-backend={}", cg_clif_dylib_path.to_str().unwrap()));
     rustflags.push_str(&format!(" --sysroot={}", DIST_DIR.to_path(dirs).to_str().unwrap()));
     if channel == "release" {
@@ -198,8 +208,7 @@ fn build_clif_sysroot_for_triple(
         use std::fmt::Write;
         write!(rustflags, " -Clinker={}", linker).unwrap();
     }
-    let mut compiler = Compiler::with_triple(triple.to_owned());
-    compiler.rustflags = rustflags;
+    compiler.rustflags += &rustflags;
     let mut build_cmd = STANDARD_LIBRARY.build(&compiler, dirs);
     if channel == "release" {
         build_cmd.arg("--release");
@@ -219,7 +228,7 @@ fn build_clif_sysroot_for_triple(
         };
         try_hard_link(
             entry.path(),
-            RUSTLIB_DIR.to_path(dirs).join(triple).join("lib").join(entry.file_name()),
+            RUSTLIB_DIR.to_path(dirs).join(&compiler.triple).join("lib").join(entry.file_name()),
         );
     }
 }

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -153,7 +153,7 @@ pub(crate) static ORIG_BUILD_SYSROOT: RelPath = RelPath::SOURCE.join("build_sysr
 pub(crate) static BUILD_SYSROOT: RelPath = RelPath::DOWNLOAD.join("sysroot");
 pub(crate) static SYSROOT_RUSTC_VERSION: RelPath = BUILD_SYSROOT.join("rustc_version");
 pub(crate) static SYSROOT_SRC: RelPath = BUILD_SYSROOT.join("sysroot_src");
-static STANDARD_LIBRARY: CargoProject = CargoProject::new(&BUILD_SYSROOT, "build_sysroot");
+pub(crate) static STANDARD_LIBRARY: CargoProject = CargoProject::new(&BUILD_SYSROOT, "build_sysroot");
 
 fn build_clif_sysroot_for_triple(
     dirs: &Dirs,

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -15,32 +15,8 @@ mod rustc_info;
 mod tests;
 mod utils;
 
-const USAGE: &str = r#"The build system of cg_clif.
-
-USAGE:
-    ./y.rs prepare [--out-dir DIR]
-    ./y.rs build [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-    ./y.rs test [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-    ./y.rs bench [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-
-OPTIONS:
-    --sysroot none|clif|llvm
-            Which sysroot libraries to use:
-            `none` will not include any standard library in the sysroot.
-            `clif` will build the standard library using Cranelift.
-            `llvm` will use the pre-compiled standard library of rustc which is compiled with LLVM.
-
-    --out-dir DIR
-            Specify the directory in which the download, build and dist directories are stored.
-            By default this is the working directory.
-
-    --no-unstable-features
-            fSome features are not yet ready for production usage. This option will disable these
-            features. This includes the JIT mode and inline assembly support.
-"#;
-
 fn usage() {
-    eprintln!("{USAGE}");
+    eprintln!("{}", include_str!("usage.txt"));
 }
 
 macro_rules! arg_error {

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -16,13 +16,22 @@ pub(crate) fn prepare(dirs: &Dirs) {
     }
     std::fs::create_dir_all(RelPath::DOWNLOAD.to_path(dirs)).unwrap();
 
+    spawn_and_wait(super::build_backend::CG_CLIF.fetch("cargo", dirs));
+
     prepare_sysroot(dirs);
+    spawn_and_wait(super::build_sysroot::STANDARD_LIBRARY.fetch("cargo", dirs));
+    spawn_and_wait(super::tests::LIBCORE_TESTS.fetch("cargo", dirs));
 
     super::abi_cafe::ABI_CAFE_REPO.fetch(dirs);
+    spawn_and_wait(super::abi_cafe::ABI_CAFE.fetch("cargo", dirs));
     super::tests::RAND_REPO.fetch(dirs);
+    spawn_and_wait(super::tests::RAND.fetch("cargo", dirs));
     super::tests::REGEX_REPO.fetch(dirs);
+    spawn_and_wait(super::tests::REGEX.fetch("cargo", dirs));
     super::tests::PORTABLE_SIMD_REPO.fetch(dirs);
+    spawn_and_wait(super::tests::PORTABLE_SIMD.fetch("cargo", dirs));
     super::bench::SIMPLE_RAYTRACER_REPO.fetch(dirs);
+    spawn_and_wait(super::bench::SIMPLE_RAYTRACER.fetch("cargo", dirs));
 }
 
 fn prepare_sysroot(dirs: &Dirs) {

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -31,6 +31,7 @@ fn prepare_sysroot(dirs: &Dirs) {
 
     eprintln!("[COPY] sysroot src");
 
+    // FIXME ensure builds error out or update the copy if any of the files copied here change
     BUILD_SYSROOT.ensure_fresh(dirs);
     copy_dir_recursively(&ORIG_BUILD_SYSROOT.to_path(dirs), &BUILD_SYSROOT.to_path(dirs));
 

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -169,9 +169,10 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
                 REGEX.source_dir(&runner.dirs).join("examples").join("regexdna-input.txt"),
             )
             .unwrap();
-            let expected_path =
-                REGEX.source_dir(&runner.dirs).join("examples").join("regexdna-output.txt");
-            let expected = fs::read_to_string(&expected_path).unwrap();
+            let expected = fs::read_to_string(
+                REGEX.source_dir(&runner.dirs).join("examples").join("regexdna-output.txt"),
+            )
+            .unwrap();
 
             let output = spawn_and_wait_with_input(run_cmd, input);
             // Make sure `[codegen mono items] start` doesn't poison the diff
@@ -184,20 +185,9 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
 
             let output_matches = expected.lines().eq(output.lines());
             if !output_matches {
-                let res_path = REGEX.source_dir(&runner.dirs).join("res.txt");
-                fs::write(&res_path, &output).unwrap();
-
-                if cfg!(windows) {
-                    println!("Output files don't match!");
-                    println!("Expected Output:\n{}", expected);
-                    println!("Actual Output:\n{}", output);
-                } else {
-                    let mut diff = Command::new("diff");
-                    diff.arg("-u");
-                    diff.arg(res_path);
-                    diff.arg(expected_path);
-                    spawn_and_wait(diff);
-                }
+                println!("Output files don't match!");
+                println!("Expected Output:\n{}", expected);
+                println!("Actual Output:\n{}", output);
 
                 std::process::exit(1);
             }

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -385,10 +385,11 @@ pub(crate) fn run_tests(
     channel: &str,
     sysroot_kind: SysrootKind,
     cg_clif_dylib: &Path,
-    host_triple: &str,
+    host_compiler: &Compiler,
     target_triple: &str,
 ) {
-    let runner = TestRunner::new(dirs.clone(), host_triple.to_string(), target_triple.to_string());
+    let runner =
+        TestRunner::new(dirs.clone(), host_compiler.triple.clone(), target_triple.to_string());
 
     if config::get_bool("testsuite.no_sysroot") {
         build_sysroot::build_sysroot(
@@ -396,7 +397,7 @@ pub(crate) fn run_tests(
             channel,
             SysrootKind::None,
             cg_clif_dylib,
-            &host_triple,
+            host_compiler,
             &target_triple,
         );
 
@@ -415,7 +416,7 @@ pub(crate) fn run_tests(
             channel,
             sysroot_kind,
             cg_clif_dylib,
-            &host_triple,
+            host_compiler,
             &target_triple,
         );
     }
@@ -445,7 +446,7 @@ impl TestRunner {
     pub fn new(dirs: Dirs, host_triple: String, target_triple: String) -> Self {
         let is_native = host_triple == target_triple;
         let jit_supported =
-            target_triple.contains("x86_64") && is_native && !host_triple.contains("windows");
+            is_native && host_triple.contains("x86_64") && !host_triple.contains("windows");
 
         let mut rustflags = env::var("RUSTFLAGS").ok().unwrap_or("".to_string());
         let mut runner = vec![];

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -97,12 +97,12 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
 pub(crate) static RAND_REPO: GitRepo =
     GitRepo::github("rust-random", "rand", "0f933f9c7176e53b2a3c7952ded484e1783f0bf1", "rand");
 
-static RAND: CargoProject = CargoProject::new(&RAND_REPO.source_dir(), "rand");
+pub(crate) static RAND: CargoProject = CargoProject::new(&RAND_REPO.source_dir(), "rand");
 
 pub(crate) static REGEX_REPO: GitRepo =
     GitRepo::github("rust-lang", "regex", "341f207c1071f7290e3f228c710817c280c8dca1", "regex");
 
-static REGEX: CargoProject = CargoProject::new(&REGEX_REPO.source_dir(), "regex");
+pub(crate) static REGEX: CargoProject = CargoProject::new(&REGEX_REPO.source_dir(), "regex");
 
 pub(crate) static PORTABLE_SIMD_REPO: GitRepo = GitRepo::github(
     "rust-lang",
@@ -111,10 +111,10 @@ pub(crate) static PORTABLE_SIMD_REPO: GitRepo = GitRepo::github(
     "portable-simd",
 );
 
-static PORTABLE_SIMD: CargoProject =
+pub(crate) static PORTABLE_SIMD: CargoProject =
     CargoProject::new(&PORTABLE_SIMD_REPO.source_dir(), "portable_simd");
 
-static LIBCORE_TESTS: CargoProject =
+pub(crate) static LIBCORE_TESTS: CargoProject =
     CargoProject::new(&SYSROOT_SRC.join("library/core/tests"), "core_tests");
 
 const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -26,24 +26,10 @@ impl TestCase {
 
 const NO_SYSROOT_SUITE: &[TestCase] = &[
     TestCase::new("build.mini_core", &|runner| {
-        runner.run_rustc([
-            "example/mini_core.rs",
-            "--crate-name",
-            "mini_core",
-            "--crate-type",
-            "lib,dylib",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/mini_core.rs", "--crate-type", "lib,dylib"]);
     }),
     TestCase::new("build.example", &|runner| {
-        runner.run_rustc([
-            "example/example.rs",
-            "--crate-type",
-            "lib",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/example.rs", "--crate-type", "lib"]);
     }),
     TestCase::new("jit.mini_core_hello_world", &|runner| {
         let mut jit_cmd = runner.rustc_command([
@@ -53,8 +39,6 @@ const NO_SYSROOT_SUITE: &[TestCase] = &[
             "example/mini_core_hello_world.rs",
             "--cfg",
             "jit",
-            "--target",
-            &runner.target_compiler.triple,
         ]);
         jit_cmd.env("CG_CLIF_JIT_ARGS", "abc bcd");
         spawn_and_wait(jit_cmd);
@@ -67,69 +51,30 @@ const NO_SYSROOT_SUITE: &[TestCase] = &[
             "example/mini_core_hello_world.rs",
             "--cfg",
             "jit",
-            "--target",
-            &runner.target_compiler.triple,
         ]);
         jit_cmd.env("CG_CLIF_JIT_ARGS", "abc bcd");
         spawn_and_wait(jit_cmd);
     }),
     TestCase::new("aot.mini_core_hello_world", &|runner| {
-        runner.run_rustc([
-            "example/mini_core_hello_world.rs",
-            "--crate-name",
-            "mini_core_hello_world",
-            "--crate-type",
-            "bin",
-            "-g",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/mini_core_hello_world.rs"]);
         runner.run_out_command("mini_core_hello_world", ["abc", "bcd"]);
     }),
 ];
 
 const BASE_SYSROOT_SUITE: &[TestCase] = &[
     TestCase::new("aot.arbitrary_self_types_pointers_and_wrappers", &|runner| {
-        runner.run_rustc([
-            "example/arbitrary_self_types_pointers_and_wrappers.rs",
-            "--crate-name",
-            "arbitrary_self_types_pointers_and_wrappers",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/arbitrary_self_types_pointers_and_wrappers.rs"]);
         runner.run_out_command("arbitrary_self_types_pointers_and_wrappers", []);
     }),
     TestCase::new("aot.issue_91827_extern_types", &|runner| {
-        runner.run_rustc([
-            "example/issue-91827-extern-types.rs",
-            "--crate-name",
-            "issue_91827_extern_types",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
-        runner.run_out_command("issue_91827_extern_types", []);
+        runner.run_rustc(["example/issue-91827-extern-types.rs"]);
+        runner.run_out_command("issue-91827-extern-types", []);
     }),
     TestCase::new("build.alloc_system", &|runner| {
-        runner.run_rustc([
-            "example/alloc_system.rs",
-            "--crate-type",
-            "lib",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/alloc_system.rs", "--crate-type", "lib"]);
     }),
     TestCase::new("aot.alloc_example", &|runner| {
-        runner.run_rustc([
-            "example/alloc_example.rs",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/alloc_example.rs"]);
         runner.run_out_command("alloc_example", []);
     }),
     TestCase::new("jit.std_example", &|runner| {
@@ -138,8 +83,6 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
             "-Cllvm-args=mode=jit",
             "-Cprefer-dynamic",
             "example/std_example.rs",
-            "--target",
-            &runner.target_compiler.triple,
         ]);
 
         eprintln!("[JIT-lazy] std_example");
@@ -148,83 +91,34 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
             "-Cllvm-args=mode=jit-lazy",
             "-Cprefer-dynamic",
             "example/std_example.rs",
-            "--target",
-            &runner.target_compiler.triple,
         ]);
     }),
     TestCase::new("aot.std_example", &|runner| {
-        runner.run_rustc([
-            "example/std_example.rs",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/std_example.rs"]);
         runner.run_out_command("std_example", ["arg"]);
     }),
     TestCase::new("aot.dst_field_align", &|runner| {
-        runner.run_rustc([
-            "example/dst-field-align.rs",
-            "--crate-name",
-            "dst_field_align",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
-        runner.run_out_command("dst_field_align", []);
+        runner.run_rustc(["example/dst-field-align.rs"]);
+        runner.run_out_command("dst-field-align", []);
     }),
     TestCase::new("aot.subslice-patterns-const-eval", &|runner| {
-        runner.run_rustc([
-            "example/subslice-patterns-const-eval.rs",
-            "--crate-type",
-            "bin",
-            "-Cpanic=abort",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/subslice-patterns-const-eval.rs"]);
         runner.run_out_command("subslice-patterns-const-eval", []);
     }),
     TestCase::new("aot.track-caller-attribute", &|runner| {
-        runner.run_rustc([
-            "example/track-caller-attribute.rs",
-            "--crate-type",
-            "bin",
-            "-Cpanic=abort",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/track-caller-attribute.rs"]);
         runner.run_out_command("track-caller-attribute", []);
     }),
     TestCase::new("aot.float-minmax-pass", &|runner| {
-        runner.run_rustc([
-            "example/float-minmax-pass.rs",
-            "--crate-type",
-            "bin",
-            "-Cpanic=abort",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/float-minmax-pass.rs"]);
         runner.run_out_command("float-minmax-pass", []);
     }),
     TestCase::new("aot.mod_bench", &|runner| {
-        runner.run_rustc([
-            "example/mod_bench.rs",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/mod_bench.rs"]);
         runner.run_out_command("mod_bench", []);
     }),
     TestCase::new("aot.issue-72793", &|runner| {
-        runner.run_rustc([
-            "example/issue-72793.rs",
-            "--crate-type",
-            "bin",
-            "--target",
-            &runner.target_compiler.triple,
-        ]);
+        runner.run_rustc(["example/issue-72793.rs"]);
         runner.run_out_command("issue-72793", []);
     }),
 ];
@@ -501,6 +395,9 @@ impl TestRunner {
         cmd.arg("--out-dir");
         cmd.arg(format!("{}", BUILD_EXAMPLE_OUT_DIR.to_path(&self.dirs).display()));
         cmd.arg("-Cdebuginfo=2");
+        cmd.arg("--target");
+        cmd.arg(&self.target_compiler.triple);
+        cmd.arg("-Cpanic=abort");
         cmd.args(args);
         cmd
     }

--- a/build_system/usage.txt
+++ b/build_system/usage.txt
@@ -1,0 +1,34 @@
+The build system of cg_clif.
+
+USAGE:
+    ./y.rs prepare [--out-dir DIR]
+    ./y.rs build [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
+    ./y.rs test [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
+    ./y.rs bench [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
+
+OPTIONS:
+    --debug
+            Build cg_clif and the standard library in debug mode rather than release mode.
+            Warning: An unoptimized cg_clif is very slow.
+
+    --sysroot none|clif|llvm
+            Which sysroot libraries to use:
+            `none` will not include any standard library in the sysroot.
+            `clif` will build the standard library using Cranelift.
+            `llvm` will use the pre-compiled standard library of rustc which is compiled with LLVM.
+
+    --out-dir DIR
+            Specify the directory in which the download, build and dist directories are stored.
+            By default this is the working directory.
+
+    --no-unstable-features
+            Some features are not yet ready for production usage. This option will disable these
+            features. This includes the JIT mode and inline assembly support.
+
+REQUIREMENTS:
+    * Rustup: The build system has a hard coded dependency on rustup to install the right nightly
+      version and make sure it is used where necessary.
+    * Git: `./y.rs prepare` uses git for applying patches and on Windows for downloading test repos.
+    * Curl and tar (non-Windows only): Used by `./y.rs prepare` to download a single commit for
+      repos. Git will be used to clone the whole repo when using Windows.
+    * [Hyperfine](https://github.com/sharkdp/hyperfine/): Used for benchmarking with `./y.rs bench`.

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -196,7 +196,14 @@ pub(crate) fn hyperfine_command(
 #[must_use]
 pub(crate) fn git_command<'a>(repo_dir: impl Into<Option<&'a Path>>, cmd: &str) -> Command {
     let mut git_cmd = Command::new("git");
-    git_cmd.arg("-c").arg("user.name=Dummy").arg("-c").arg("user.email=dummy@example.com").arg(cmd);
+    git_cmd
+        .arg("-c")
+        .arg("user.name=Dummy")
+        .arg("-c")
+        .arg("user.email=dummy@example.com")
+        .arg("-c")
+        .arg("core.autocrlf=false")
+        .arg(cmd);
     if let Some(repo_dir) = repo_dir.into() {
         git_cmd.current_dir(repo_dir);
     }

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -111,7 +111,8 @@ impl CargoProject {
             .arg("--manifest-path")
             .arg(self.manifest_path(dirs))
             .arg("--target-dir")
-            .arg(self.target_dir(dirs));
+            .arg(self.target_dir(dirs))
+            .arg("--frozen");
 
         cmd
     }

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 
 use super::path::{Dirs, RelPath};
-use super::rustc_info::{
-    get_cargo_path, get_host_triple, get_rustc_path, get_rustdoc_path, get_wrapper_file_name,
-};
+use super::rustc_info::{get_cargo_path, get_rustc_path, get_rustdoc_path, get_wrapper_file_name};
 
+#[derive(Clone, Debug)]
 pub(crate) struct Compiler {
     pub(crate) cargo: PathBuf,
     pub(crate) rustc: PathBuf,
@@ -20,19 +19,7 @@ pub(crate) struct Compiler {
 }
 
 impl Compiler {
-    pub(crate) fn host() -> Compiler {
-        Compiler {
-            cargo: get_cargo_path(),
-            rustc: get_rustc_path(),
-            rustdoc: get_rustdoc_path(),
-            rustflags: String::new(),
-            rustdocflags: String::new(),
-            triple: get_host_triple(),
-            runner: vec![],
-        }
-    }
-
-    pub(crate) fn with_triple(triple: String) -> Compiler {
+    pub(crate) fn llvm_with_triple(triple: String) -> Compiler {
         Compiler {
             cargo: get_cargo_path(),
             rustc: get_rustc_path(),

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -47,6 +47,38 @@ impl Compiler {
             runner: vec![],
         }
     }
+
+    pub(crate) fn set_cross_linker_and_runner(&mut self) {
+        match self.triple.as_str() {
+            "aarch64-unknown-linux-gnu" => {
+                // We are cross-compiling for aarch64. Use the correct linker and run tests in qemu.
+                self.rustflags += " -Clinker=aarch64-linux-gnu-gcc";
+                self.rustdocflags += " -Clinker=aarch64-linux-gnu-gcc";
+                self.runner = vec![
+                    "qemu-aarch64".to_owned(),
+                    "-L".to_owned(),
+                    "/usr/aarch64-linux-gnu".to_owned(),
+                ];
+            }
+            "s390x-unknown-linux-gnu" => {
+                // We are cross-compiling for s390x. Use the correct linker and run tests in qemu.
+                self.rustflags += " -Clinker=s390x-linux-gnu-gcc";
+                self.rustdocflags += " -Clinker=s390x-linux-gnu-gcc";
+                self.runner = vec![
+                    "qemu-s390x".to_owned(),
+                    "-L".to_owned(),
+                    "/usr/s390x-linux-gnu".to_owned(),
+                ];
+            }
+            "x86_64-pc-windows-gnu" => {
+                // We are cross-compiling for Windows. Run tests in wine.
+                self.runner = vec!["wine".to_owned()];
+            }
+            _ => {
+                println!("Unknown non-native platform");
+            }
+        }
+    }
 }
 
 pub(crate) struct CargoProject {

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -103,6 +103,7 @@ impl CargoProject {
         RelPath::BUILD.join(self.target).to_path(dirs)
     }
 
+    #[must_use]
     fn base_cmd(&self, command: &str, cargo: &Path, dirs: &Dirs) -> Command {
         let mut cmd = Command::new(cargo);
 
@@ -115,6 +116,7 @@ impl CargoProject {
         cmd
     }
 
+    #[must_use]
     fn build_cmd(&self, command: &str, compiler: &Compiler, dirs: &Dirs) -> Command {
         let mut cmd = self.base_cmd(command, &compiler.cargo, dirs);
 
@@ -189,6 +191,16 @@ pub(crate) fn hyperfine_command(
     bench.arg(a).arg(b);
 
     bench
+}
+
+#[must_use]
+pub(crate) fn git_command<'a>(repo_dir: impl Into<Option<&'a Path>>, cmd: &str) -> Command {
+    let mut git_cmd = Command::new("git");
+    git_cmd.arg("-c").arg("user.name=Dummy").arg("-c").arg("user.email=dummy@example.com").arg(cmd);
+    if let Some(repo_dir) = repo_dir.into() {
+        git_cmd.current_dir(repo_dir);
+    }
+    git_cmd
 }
 
 #[track_caller]

--- a/scripts/setup_rust_fork.sh
+++ b/scripts/setup_rust_fork.sh
@@ -10,7 +10,7 @@ git fetch
 git checkout -- .
 git checkout "$(rustc -V | cut -d' ' -f3 | tr -d '(')"
 
-git am ../patches/*-sysroot-*.patch
+git -c user.name=Dummy -c user.email=dummy@example.com am ../patches/*-sysroot-*.patch
 
 git apply - <<EOF
 diff --git a/library/alloc/Cargo.toml b/library/alloc/Cargo.toml

--- a/y.rs
+++ b/y.rs
@@ -3,7 +3,7 @@
 # This block is ignored by rustc
 set -e
 echo "[BUILD] y.rs" 1>&2
-rustc $0 -o ${0/.rs/.bin} -Cdebuginfo=1 --edition 2021
+rustc $0 -o ${0/.rs/.bin} -Cdebuginfo=1 --edition 2021 -Cpanic=abort
 exec ${0/.rs/.bin} $@
 */
 


### PR DESCRIPTION
* Share cross-compilation code between building and testing
* General cleanup of testing code
* Enable sparse cargo registry on CI
* Set `core.autocrlf=false` in the build system rather than on CI
* Fetch all cargo dependencies in ./y.rs prepare
* Improve readme and build system help message

Part of https://github.com/bjorn3/rustc_codegen_cranelift/issues/1290