### PR TITLE
Push up a lot of rustc and cargo references

### DIFF
--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -18,7 +18,7 @@ pub(crate) fn run(
     sysroot_kind: SysrootKind,
     dirs: &Dirs,
     cg_clif_dylib: &Path,
-    host_compiler: &Compiler,
+    bootstrap_host_compiler: &Compiler,
 ) {
     if !config::get_bool("testsuite.abi-cafe") {
         eprintln!("[RUN] abi-cafe (skipped)");
@@ -31,15 +31,15 @@ pub(crate) fn run(
         channel,
         sysroot_kind,
         cg_clif_dylib,
-        host_compiler,
-        &host_compiler.triple,
+        bootstrap_host_compiler,
+        &bootstrap_host_compiler.triple,
     );
 
     eprintln!("Running abi-cafe");
 
     let pairs = ["rustc_calls_cgclif", "cgclif_calls_rustc", "cgclif_calls_cc", "cc_calls_cgclif"];
 
-    let mut cmd = ABI_CAFE.run(host_compiler, dirs);
+    let mut cmd = ABI_CAFE.run(bootstrap_host_compiler, dirs);
     cmd.arg("--");
     cmd.arg("--pairs");
     cmd.args(pairs);

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -32,7 +32,7 @@ pub(crate) fn run(
         sysroot_kind,
         cg_clif_dylib,
         bootstrap_host_compiler,
-        &bootstrap_host_compiler.triple,
+        bootstrap_host_compiler.triple.clone(),
     );
 
     eprintln!("Running abi-cafe");

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -21,7 +21,7 @@ pub(crate) fn run(
     host_compiler: &Compiler,
 ) {
     if !config::get_bool("testsuite.abi-cafe") {
-        eprintln!("[SKIP] abi-cafe");
+        eprintln!("[RUN] abi-cafe (skipped)");
         return;
     }
 

--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -21,11 +21,11 @@ pub(crate) static SIMPLE_RAYTRACER_LLVM: CargoProject =
 pub(crate) static SIMPLE_RAYTRACER: CargoProject =
     CargoProject::new(&SIMPLE_RAYTRACER_REPO.source_dir(), "simple_raytracer");
 
-pub(crate) fn benchmark(dirs: &Dirs, host_compiler: &Compiler) {
-    benchmark_simple_raytracer(dirs, host_compiler);
+pub(crate) fn benchmark(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
+    benchmark_simple_raytracer(dirs, bootstrap_host_compiler);
 }
 
-fn benchmark_simple_raytracer(dirs: &Dirs, host_compiler: &Compiler) {
+fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
     if std::process::Command::new("hyperfine").output().is_err() {
         eprintln!("Hyperfine not installed");
         eprintln!("Hint: Try `cargo install hyperfine` to install hyperfine");
@@ -33,12 +33,12 @@ fn benchmark_simple_raytracer(dirs: &Dirs, host_compiler: &Compiler) {
     }
 
     eprintln!("[LLVM BUILD] simple-raytracer");
-    let build_cmd = SIMPLE_RAYTRACER_LLVM.build(host_compiler, dirs);
+    let build_cmd = SIMPLE_RAYTRACER_LLVM.build(bootstrap_host_compiler, dirs);
     spawn_and_wait(build_cmd);
     fs::copy(
         SIMPLE_RAYTRACER_LLVM
             .target_dir(dirs)
-            .join(&host_compiler.triple)
+            .join(&bootstrap_host_compiler.triple)
             .join("debug")
             .join(get_file_name("main", "bin")),
         RelPath::BUILD.to_path(dirs).join(get_file_name("raytracer_cg_llvm", "bin")),

--- a/build_system/build_backend.rs
+++ b/build_system/build_backend.rs
@@ -10,10 +10,10 @@ pub(crate) static CG_CLIF: CargoProject = CargoProject::new(&RelPath::SOURCE, "c
 pub(crate) fn build_backend(
     dirs: &Dirs,
     channel: &str,
-    host_compiler: &Compiler,
+    bootstrap_host_compiler: &Compiler,
     use_unstable_features: bool,
 ) -> PathBuf {
-    let mut cmd = CG_CLIF.build(&host_compiler, dirs);
+    let mut cmd = CG_CLIF.build(&bootstrap_host_compiler, dirs);
 
     cmd.env("CARGO_BUILD_INCREMENTAL", "true"); // Force incr comp even in release mode
 
@@ -48,7 +48,7 @@ pub(crate) fn build_backend(
 
     CG_CLIF
         .target_dir(dirs)
-        .join(&host_compiler.triple)
+        .join(&bootstrap_host_compiler.triple)
         .join(channel)
         .join(get_file_name("rustc_codegen_cranelift", "dylib"))
 }

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use std::process::{self, Command};
 
 use super::path::{Dirs, RelPath};
-use super::rustc_info::{get_file_name, get_rustc_version, get_wrapper_file_name};
+use super::rustc_info::{
+    get_file_name, get_rustc_version, get_toolchain_name, get_wrapper_file_name,
+};
 use super::utils::{spawn_and_wait, try_hard_link, CargoProject, Compiler};
 use super::SysrootKind;
 
@@ -44,8 +46,9 @@ pub(crate) fn build_sysroot(
     for wrapper in ["rustc-clif", "rustdoc-clif", "cargo-clif"] {
         let wrapper_name = get_wrapper_file_name(wrapper, "bin");
 
-        let mut build_cargo_wrapper_cmd = Command::new("rustc");
+        let mut build_cargo_wrapper_cmd = Command::new(&bootstrap_host_compiler.rustc);
         build_cargo_wrapper_cmd
+            .env("TOOLCHAIN_NAME", get_toolchain_name())
             .arg(RelPath::SCRIPTS.to_path(dirs).join(&format!("{wrapper}.rs")))
             .arg("-o")
             .arg(DIST_DIR.to_path(dirs).join(wrapper_name))

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -53,7 +53,7 @@ pub(crate) fn build_sysroot(
         spawn_and_wait(build_cargo_wrapper_cmd);
     }
 
-    let default_sysroot = super::rustc_info::get_default_sysroot();
+    let default_sysroot = super::rustc_info::get_default_sysroot(&bootstrap_host_compiler.rustc);
 
     let host_rustlib_lib =
         RUSTLIB_DIR.to_path(dirs).join(&bootstrap_host_compiler.triple).join("lib");
@@ -182,7 +182,7 @@ fn build_clif_sysroot_for_triple(
             process::exit(1);
         }
         Ok(source_version) => {
-            let rustc_version = get_rustc_version();
+            let rustc_version = get_rustc_version(&compiler.rustc);
             if source_version != rustc_version {
                 eprintln!("The patched sysroot source is outdated");
                 eprintln!("Source version: {}", source_version.trim());

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -134,6 +134,9 @@ pub fn main() {
         process::exit(0);
     }
 
+    env::set_var("RUSTC", "rustc_should_be_set_explicitly");
+    env::set_var("RUSTDOC", "rustdoc_should_be_set_explicitly");
+
     let cg_clif_dylib =
         build_backend::build_backend(&dirs, channel, &host_compiler, use_unstable_features);
     match command {

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -154,7 +154,7 @@ pub fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
-                &target_triple,
+                target_triple.clone(),
             );
 
             if bootstrap_host_compiler.triple == target_triple {
@@ -177,7 +177,7 @@ pub fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
-                &target_triple,
+                target_triple,
             );
         }
         Command::Bench => {
@@ -187,7 +187,7 @@ pub fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
-                &target_triple,
+                target_triple,
             );
             bench::benchmark(&dirs, &bootstrap_host_compiler);
         }

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -153,7 +153,7 @@ pub fn main() {
             if host_compiler.triple == target_triple {
                 abi_cafe::run(channel, sysroot_kind, &dirs, &cg_clif_dylib, &host_compiler);
             } else {
-                eprintln!("[SKIP] abi-cafe (cross-compilation not supported)");
+                eprintln!("[RUN] abi-cafe (skipped, cross-compilation not supported)");
                 return;
             }
         }

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -35,7 +35,7 @@ pub(crate) fn prepare(dirs: &Dirs) {
 }
 
 fn prepare_sysroot(dirs: &Dirs) {
-    let sysroot_src_orig = get_default_sysroot().join("lib/rustlib/src/rust");
+    let sysroot_src_orig = get_default_sysroot(Path::new("rustc")).join("lib/rustlib/src/rust");
     assert!(sysroot_src_orig.exists());
 
     eprintln!("[COPY] sysroot src");
@@ -50,7 +50,7 @@ fn prepare_sysroot(dirs: &Dirs) {
         &SYSROOT_SRC.to_path(dirs).join("library"),
     );
 
-    let rustc_version = get_rustc_version();
+    let rustc_version = get_rustc_version(Path::new("rustc"));
     fs::write(SYSROOT_RUSTC_VERSION.to_path(dirs), &rustc_version).unwrap();
 
     eprintln!("[GIT] init");

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -23,6 +23,16 @@ pub(crate) fn get_host_triple() -> String {
         .to_owned()
 }
 
+pub(crate) fn get_toolchain_name() -> String {
+    let active_toolchain = Command::new("rustup")
+        .stderr(Stdio::inherit())
+        .args(&["show", "active-toolchain"])
+        .output()
+        .unwrap()
+        .stdout;
+    String::from_utf8(active_toolchain).unwrap().trim().split_once(' ').unwrap().0.to_owned()
+}
+
 pub(crate) fn get_cargo_path() -> PathBuf {
     let cargo_path = Command::new("rustup")
         .stderr(Stdio::inherit())

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-pub(crate) fn get_rustc_version() -> String {
+pub(crate) fn get_rustc_version(rustc: &Path) -> String {
     let version_info =
-        Command::new("rustc").stderr(Stdio::inherit()).args(&["-V"]).output().unwrap().stdout;
+        Command::new(rustc).stderr(Stdio::inherit()).args(&["-V"]).output().unwrap().stdout;
     String::from_utf8(version_info).unwrap()
 }
 
@@ -53,8 +53,8 @@ pub(crate) fn get_rustdoc_path() -> PathBuf {
     Path::new(String::from_utf8(rustc_path).unwrap().trim()).to_owned()
 }
 
-pub(crate) fn get_default_sysroot() -> PathBuf {
-    let default_sysroot = Command::new("rustc")
+pub(crate) fn get_default_sysroot(rustc: &Path) -> PathBuf {
+    let default_sysroot = Command::new(rustc)
         .stderr(Stdio::inherit())
         .args(&["--print", "sysroot"])
         .output()

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -3,6 +3,7 @@ use super::build_sysroot::{self, SYSROOT_SRC};
 use super::config;
 use super::path::{Dirs, RelPath};
 use super::prepare::GitRepo;
+use super::rustc_info::get_host_triple;
 use super::utils::{spawn_and_wait, spawn_and_wait_with_input, CargoProject, Compiler};
 use super::SysrootKind;
 use std::env;
@@ -240,14 +241,11 @@ pub(crate) fn run_tests(
     channel: &str,
     sysroot_kind: SysrootKind,
     cg_clif_dylib: &Path,
-    host_compiler: &Compiler,
+    bootstrap_host_compiler: &Compiler,
     target_triple: &str,
 ) {
-    let runner = TestRunner::new(
-        dirs.clone(),
-        target_triple.to_owned(),
-        host_compiler.triple == target_triple,
-    );
+    let runner =
+        TestRunner::new(dirs.clone(), target_triple.to_owned(), get_host_triple() == target_triple);
 
     if config::get_bool("testsuite.no_sysroot") {
         build_sysroot::build_sysroot(
@@ -255,7 +253,7 @@ pub(crate) fn run_tests(
             channel,
             SysrootKind::None,
             cg_clif_dylib,
-            host_compiler,
+            bootstrap_host_compiler,
             &target_triple,
         );
 
@@ -274,7 +272,7 @@ pub(crate) fn run_tests(
             channel,
             sysroot_kind,
             cg_clif_dylib,
-            host_compiler,
+            bootstrap_host_compiler,
             &target_triple,
         );
     }

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -119,7 +119,7 @@ pub(crate) static LIBCORE_TESTS: CargoProject =
 
 const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
     TestCase::custom("test.rust-random/rand", &|runner| {
-        spawn_and_wait(RAND.clean(&runner.target_compiler.cargo, &runner.dirs));
+        RAND.clean(&runner.dirs);
 
         if runner.is_native {
             eprintln!("[TEST] rust-random/rand");
@@ -134,11 +134,11 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
         }
     }),
     TestCase::custom("test.simple-raytracer", &|runner| {
-        spawn_and_wait(SIMPLE_RAYTRACER.clean(&runner.host_compiler.cargo, &runner.dirs));
+        SIMPLE_RAYTRACER.clean(&runner.dirs);
         spawn_and_wait(SIMPLE_RAYTRACER.build(&runner.target_compiler, &runner.dirs));
     }),
     TestCase::custom("test.libcore", &|runner| {
-        spawn_and_wait(LIBCORE_TESTS.clean(&runner.host_compiler.cargo, &runner.dirs));
+        LIBCORE_TESTS.clean(&runner.dirs);
 
         if runner.is_native {
             spawn_and_wait(LIBCORE_TESTS.test(&runner.target_compiler, &runner.dirs));
@@ -150,7 +150,7 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
         }
     }),
     TestCase::custom("test.regex-shootout-regex-dna", &|runner| {
-        spawn_and_wait(REGEX.clean(&runner.target_compiler.cargo, &runner.dirs));
+        REGEX.clean(&runner.dirs);
 
         // newer aho_corasick versions throw a deprecation warning
         let lint_rust_flags = format!("{} --cap-lints warn", runner.target_compiler.rustflags);
@@ -194,7 +194,7 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
         }
     }),
     TestCase::custom("test.regex", &|runner| {
-        spawn_and_wait(REGEX.clean(&runner.host_compiler.cargo, &runner.dirs));
+        REGEX.clean(&runner.dirs);
 
         // newer aho_corasick versions throw a deprecation warning
         let lint_rust_flags = format!("{} --cap-lints warn", runner.target_compiler.rustflags);
@@ -221,7 +221,7 @@ const EXTENDED_SYSROOT_SUITE: &[TestCase] = &[
         }
     }),
     TestCase::custom("test.portable-simd", &|runner| {
-        spawn_and_wait(PORTABLE_SIMD.clean(&runner.host_compiler.cargo, &runner.dirs));
+        PORTABLE_SIMD.clean(&runner.dirs);
 
         let mut build_cmd = PORTABLE_SIMD.build(&runner.target_compiler, &runner.dirs);
         build_cmd.arg("--all-targets");
@@ -293,7 +293,6 @@ struct TestRunner {
     is_native: bool,
     jit_supported: bool,
     dirs: Dirs,
-    host_compiler: Compiler,
     target_compiler: Compiler,
 }
 
@@ -302,8 +301,6 @@ impl TestRunner {
         let is_native = host_triple == target_triple;
         let jit_supported =
             is_native && host_triple.contains("x86_64") && !host_triple.contains("windows");
-
-        let host_compiler = Compiler::clif_with_triple(&dirs, host_triple);
 
         let mut target_compiler = Compiler::clif_with_triple(&dirs, target_triple);
         if !is_native {
@@ -323,7 +320,7 @@ impl TestRunner {
             target_compiler.rustflags.push_str(" -Clink-arg=-undefined -Clink-arg=dynamic_lookup");
         }
 
-        Self { is_native, jit_supported, dirs, host_compiler, target_compiler }
+        Self { is_native, jit_supported, dirs, target_compiler }
     }
 
     pub fn run_testsuite(&self, tests: &[TestCase]) {

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -19,7 +19,7 @@ pub(crate) struct Compiler {
 }
 
 impl Compiler {
-    pub(crate) fn llvm_with_triple(triple: String) -> Compiler {
+    pub(crate) fn bootstrap_with_triple(triple: String) -> Compiler {
         Compiler {
             cargo: get_cargo_path(),
             rustc: get_rustc_path(),

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -146,9 +146,8 @@ impl CargoProject {
         cmd
     }
 
-    #[must_use]
-    pub(crate) fn clean(&self, cargo: &Path, dirs: &Dirs) -> Command {
-        self.base_cmd("clean", cargo, dirs)
+    pub(crate) fn clean(&self, dirs: &Dirs) {
+        let _ = fs::remove_dir_all(self.target_dir(dirs));
     }
 
     #[must_use]

--- a/scripts/cargo-clif.rs
+++ b/scripts/cargo-clif.rs
@@ -26,7 +26,7 @@ fn main() {
     env::set_var("RUSTDOCFLAGS", env::var("RUSTDOCFLAGS").unwrap_or(String::new()) + &rustflags);
 
     // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("RUSTUP_TOOLCHAIN"));
+    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
 
     let args: Vec<_> = match env::args().nth(1).as_deref() {
         Some("jit") => {

--- a/scripts/rustc-clif.rs
+++ b/scripts/rustc-clif.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("RUSTUP_TOOLCHAIN"));
+    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
 
     #[cfg(unix)]
     Command::new("rustc").args(args).exec();

--- a/scripts/rustdoc-clif.rs
+++ b/scripts/rustdoc-clif.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("RUSTUP_TOOLCHAIN"));
+    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
 
     #[cfg(unix)]
     Command::new("rustdoc").args(args).exec();


### PR DESCRIPTION
To make it easier to allow using the specific rustc toolchain built by ./x.py rather than the one specified by rust-toolchain in the future  when running as part of rust's CI.

Part of https://github.com/bjorn3/rustc_codegen_cranelift/issues/1290