### PR TITLE
Refactor sysroot building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-mingw-w64-x86-64 wine-stable
-        rustup target add x86_64-pc-windows-gnu
 
     - name: Install AArch64 toolchain and qemu
       if: matrix.os == 'ubuntu-latest' && matrix.env.TARGET_TRIPLE == 'aarch64-unknown-linux-gnu'

--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::path::{Dirs, RelPath};
 use super::prepare::GitRepo;
-use super::rustc_info::{get_file_name, get_wrapper_file_name};
+use super::rustc_info::get_file_name;
 use super::utils::{hyperfine_command, is_ci, spawn_and_wait, CargoProject, Compiler};
 
 pub(crate) static SIMPLE_RAYTRACER_REPO: GitRepo = GitRepo::github(
@@ -51,7 +51,8 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
         .unwrap();
 
     eprintln!("[BENCH COMPILE] ebobby/simple-raytracer");
-    let cargo_clif = RelPath::DIST.to_path(dirs).join(get_wrapper_file_name("cargo-clif", "bin"));
+    let cargo_clif =
+        RelPath::DIST.to_path(dirs).join(get_file_name("cargo_clif", "bin").replace('_', "-"));
     let manifest_path = SIMPLE_RAYTRACER.manifest_path(dirs);
     let target_dir = SIMPLE_RAYTRACER.target_dir(dirs);
 

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -103,6 +103,10 @@ struct SysrootTarget {
 
 impl SysrootTarget {
     fn install_into_sysroot(&self, sysroot: &Path) {
+        if self.libs.is_empty() {
+            return;
+        }
+
         let target_rustlib_lib = sysroot.join("lib").join("rustlib").join(&self.triple).join("lib");
         fs::create_dir_all(&target_rustlib_lib).unwrap();
 

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -93,12 +93,3 @@ pub(crate) fn get_file_name(crate_name: &str, crate_type: &str) -> String {
     assert!(file_name.contains(crate_name));
     file_name
 }
-
-/// Similar to `get_file_name`, but converts any dashes (`-`) in the `crate_name` to
-/// underscores (`_`). This is specially made for the rustc and cargo wrappers
-/// which have a dash in the name, and that is not allowed in a crate name.
-pub(crate) fn get_wrapper_file_name(crate_name: &str, crate_type: &str) -> String {
-    let crate_name = crate_name.replace('-', "_");
-    let wrapper_name = get_file_name(&crate_name, crate_type);
-    wrapper_name.replace('_', "-")
-}

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 
 use super::path::{Dirs, RelPath};
-use super::rustc_info::{get_cargo_path, get_rustc_path, get_rustdoc_path, get_wrapper_file_name};
+use super::rustc_info::{get_cargo_path, get_rustc_path, get_rustdoc_path};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Compiler {
@@ -24,23 +24,6 @@ impl Compiler {
             cargo: get_cargo_path(),
             rustc: get_rustc_path(),
             rustdoc: get_rustdoc_path(),
-            rustflags: String::new(),
-            rustdocflags: String::new(),
-            triple,
-            runner: vec![],
-        }
-    }
-
-    pub(crate) fn clif_with_triple(dirs: &Dirs, triple: String) -> Compiler {
-        let rustc_clif =
-            RelPath::DIST.to_path(&dirs).join(get_wrapper_file_name("rustc-clif", "bin"));
-        let rustdoc_clif =
-            RelPath::DIST.to_path(&dirs).join(get_wrapper_file_name("rustdoc-clif", "bin"));
-
-        Compiler {
-            cargo: get_cargo_path(),
-            rustc: rustc_clif.clone(),
-            rustdoc: rustdoc_clif.clone(),
             rustflags: String::new(),
             rustdocflags: String::new(),
             triple,


### PR DESCRIPTION
* Don't require an existing sysroot when building for MinGW
* Add MinGW rtstartup objects to the sysroot for the host, not just for the target.
* Introduce SysrootTarget to centralize assembling the sysroot a bit
* Make sysroot assembling faster

Part of https://github.com/bjorn3/rustc_codegen_cranelift/issues/1290