### PR TITLE
Implement vendoring

### DIFF
--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -6,14 +6,14 @@ use std::process::{Command, Stdio};
 use super::build_sysroot::{BUILD_SYSROOT, ORIG_BUILD_SYSROOT, SYSROOT_RUSTC_VERSION, SYSROOT_SRC};
 use super::path::{Dirs, RelPath};
 use super::rustc_info::{get_default_sysroot, get_rustc_version};
-use super::utils::{copy_dir_recursively, git_command, retry_spawn_and_wait, spawn_and_wait};
+use super::utils::{
+    copy_dir_recursively, git_command, remove_file_if_exists, retry_spawn_and_wait, spawn_and_wait,
+};
 
 pub(crate) fn prepare(dirs: &Dirs, vendor: bool) {
     RelPath::DOWNLOAD.ensure_fresh(dirs);
 
-    if Path::new(".cargo/config.toml").exists() {
-        std::fs::remove_file(".cargo/config.toml").unwrap();
-    }
+    remove_file_if_exists(Path::new(".cargo/config.toml"));
 
     let mut cargo_workspaces = vec![super::build_backend::CG_CLIF.manifest_path(dirs)];
 

--- a/build_system/usage.txt
+++ b/build_system/usage.txt
@@ -1,6 +1,7 @@
 The build system of cg_clif.
 
 USAGE:
+    ./y.rs vendor
     ./y.rs prepare [--out-dir DIR]
     ./y.rs build [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
     ./y.rs test [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -237,6 +237,14 @@ pub(crate) fn spawn_and_wait_with_input(mut cmd: Command, input: String) -> Stri
     String::from_utf8(output.stdout).unwrap()
 }
 
+pub(crate) fn remove_file_if_exists(path: &Path) {
+    match fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => panic!("Failed to remove {path}: {err}", path = path.display()),
+    }
+}
+
 pub(crate) fn remove_dir_if_exists(path: &Path) {
     match fs::remove_dir_all(&path) {
         Ok(()) => {}

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -120,15 +120,6 @@ impl CargoProject {
         cmd
     }
 
-    #[must_use]
-    pub(crate) fn fetch(&self, cargo: impl AsRef<Path>, dirs: &Dirs) -> Command {
-        let mut cmd = Command::new(cargo.as_ref());
-
-        cmd.arg("fetch").arg("--manifest-path").arg(self.manifest_path(dirs));
-
-        cmd
-    }
-
     pub(crate) fn clean(&self, dirs: &Dirs) {
         let _ = fs::remove_dir_all(self.target_dir(dirs));
     }

--- a/clean_all.sh
+++ b/clean_all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-rm -rf target/ download/ build/ dist/ y.bin y.bin.dSYM y.exe y.pdb
+rm -rf .cargo/config.toml target/ download/ build/ dist/ y.bin y.bin.dSYM y.exe y.pdb
 
 # Kept for now in case someone updates their checkout of cg_clif before running clean_all.sh
 # FIXME remove at some point in the future


### PR DESCRIPTION
Part of https://github.com/bjorn3/rustc_codegen_cranelift/issues/1290

`./y.rs vendor` will vendor everything that needs to be fetched from the internet into `download/`. After vendoring you shouldn't use `./y.rs prepare`.