### PR TITLE
Use patched git-subtree from bjorn3/git@tqc-subtree-portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ perf.data.old
 /dist
 /rust
 /download
+/git-fixed-subtree.sh

--- a/scripts/rustup.sh
+++ b/scripts/rustup.sh
@@ -4,6 +4,20 @@ set -e
 
 TOOLCHAIN=${TOOLCHAIN:-$(date +%Y-%m-%d)}
 
+function check_git_fixed_subtree() {
+    if [[ ! -e ./git-fixed-subtree.sh ]]; then
+        echo "Missing git-fixed-subtree.sh. Please run the following commands to download it:"
+        echo "curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/bjorn3/git/tqc-subtree-portable/contrib/subtree/git-subtree.sh -o git-fixed-subtree.sh"
+        echo "chmod u+x git-fixed-subtree.sh"
+        exit 1
+    fi
+    if [[ ! -x ./git-fixed-subtree.sh ]]; then
+        echo "git-fixed-subtree.sh is not executable. Please run the following command to make it executable:"
+        echo "chmod u+x git-fixed-subtree.sh"
+        exit 1
+    fi
+}
+
 case $1 in
     "prepare")
         echo "=> Installing new nightly"
@@ -27,21 +41,25 @@ case $1 in
         git commit -m "Rustup to $(rustc -V)"
         ;;
     "push")
+        check_git_fixed_subtree
+
         cg_clif=$(pwd)
         pushd ../rust
         git pull origin master
         branch=sync_cg_clif-$(date +%Y-%m-%d)
         git checkout -b "$branch"
-        git subtree pull --prefix=compiler/rustc_codegen_cranelift/ https://github.com/bjorn3/rustc_codegen_cranelift.git master
+        "$cg_clif/git-fixed-subtree.sh" pull --prefix=compiler/rustc_codegen_cranelift/ https://github.com/bjorn3/rustc_codegen_cranelift.git master
         git push -u my "$branch"
 
         # immediately merge the merge commit into cg_clif to prevent merge conflicts when syncing
         # from rust-lang/rust later
-        git subtree push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
+        "$cg_clif/git-fixed-subtree.sh" push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
         popd
         git merge sync_from_rust
 	;;
     "pull")
+        check_git_fixed_subtree
+
         RUST_VERS=$(curl "https://static.rust-lang.org/dist/$TOOLCHAIN/channel-rust-nightly-git-commit-hash.txt")
         echo "Pulling $RUST_VERS ($TOOLCHAIN)"
 
@@ -49,7 +67,7 @@ case $1 in
         pushd ../rust
         git fetch origin master
         git checkout "$RUST_VERS"
-        git subtree push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
+        "$cg_clif/git-fixed-subtree.sh" push --prefix=compiler/rustc_codegen_cranelift/ "$cg_clif" sync_from_rust
         popd
         git merge sync_from_rust -m "Sync from rust $RUST_VERS"
         git branch -d sync_from_rust


### PR DESCRIPTION
This patched has been necessary for subtree syncs from the start, but previously it was necessary to locally install tqc's patched git version, which hasn't been updated for quite a while. I made a small change to allow downloading it as script without requiring an entire git installation for the patched version.