### PR TITLE
Benchmark clif release builds with ./y.rs bench

### DIFF
--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -1,11 +1,10 @@
 use std::env;
-use std::fs;
 use std::path::Path;
 
 use super::path::{Dirs, RelPath};
 use super::prepare::GitRepo;
 use super::rustc_info::get_file_name;
-use super::utils::{hyperfine_command, spawn_and_wait, CargoProject, Compiler};
+use super::utils::{hyperfine_command, spawn_and_wait};
 
 static SIMPLE_RAYTRACER_REPO: GitRepo = GitRepo::github(
     "ebobby",
@@ -14,18 +13,11 @@ static SIMPLE_RAYTRACER_REPO: GitRepo = GitRepo::github(
     "<none>",
 );
 
-// Use a separate target dir for the initial LLVM build to reduce unnecessary recompiles
-static SIMPLE_RAYTRACER_LLVM: CargoProject =
-    CargoProject::new(&SIMPLE_RAYTRACER_REPO.source_dir(), "simple_raytracer_llvm");
-
-static SIMPLE_RAYTRACER: CargoProject =
-    CargoProject::new(&SIMPLE_RAYTRACER_REPO.source_dir(), "simple_raytracer");
-
-pub(crate) fn benchmark(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
-    benchmark_simple_raytracer(dirs, bootstrap_host_compiler);
+pub(crate) fn benchmark(dirs: &Dirs) {
+    benchmark_simple_raytracer(dirs);
 }
 
-fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
+fn benchmark_simple_raytracer(dirs: &Dirs) {
     if std::process::Command::new("hyperfine").output().is_err() {
         eprintln!("Hyperfine not installed");
         eprintln!("Hint: Try `cargo install hyperfine` to install hyperfine");
@@ -34,33 +26,15 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
 
     if !SIMPLE_RAYTRACER_REPO.source_dir().to_path(dirs).exists() {
         SIMPLE_RAYTRACER_REPO.fetch(dirs);
-        spawn_and_wait(SIMPLE_RAYTRACER.fetch(
-            &bootstrap_host_compiler.cargo,
-            &bootstrap_host_compiler.rustc,
-            dirs,
-        ));
     }
-
-    eprintln!("[LLVM BUILD] simple-raytracer");
-    let build_cmd = SIMPLE_RAYTRACER_LLVM.build(bootstrap_host_compiler, dirs);
-    spawn_and_wait(build_cmd);
-    fs::copy(
-        SIMPLE_RAYTRACER_LLVM
-            .target_dir(dirs)
-            .join(&bootstrap_host_compiler.triple)
-            .join("debug")
-            .join(get_file_name("main", "bin")),
-        RelPath::BUILD.to_path(dirs).join(get_file_name("raytracer_cg_llvm", "bin")),
-    )
-    .unwrap();
 
     let bench_runs = env::var("BENCH_RUNS").unwrap_or_else(|_| "10".to_string()).parse().unwrap();
 
     eprintln!("[BENCH COMPILE] ebobby/simple-raytracer");
     let cargo_clif =
         RelPath::DIST.to_path(dirs).join(get_file_name("cargo_clif", "bin").replace('_', "-"));
-    let manifest_path = SIMPLE_RAYTRACER.manifest_path(dirs);
-    let target_dir = SIMPLE_RAYTRACER.target_dir(dirs);
+    let manifest_path = SIMPLE_RAYTRACER_REPO.source_dir().to_path(dirs).join("Cargo.toml");
+    let target_dir = RelPath::BUILD.join("simple_raytracer").to_path(dirs);
 
     let clean_cmd = format!(
         "RUSTC=rustc cargo clean --manifest-path {manifest_path} --target-dir {target_dir}",
@@ -68,28 +42,33 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
         target_dir = target_dir.display(),
     );
     let llvm_build_cmd = format!(
-        "RUSTC=rustc cargo build --manifest-path {manifest_path} --target-dir {target_dir}",
+        "RUSTC=rustc cargo build --manifest-path {manifest_path} --target-dir {target_dir} && (rm build/raytracer_cg_llvm || true) && ln build/simple_raytracer/debug/main build/raytracer_cg_llvm",
         manifest_path = manifest_path.display(),
         target_dir = target_dir.display(),
     );
     let clif_build_cmd = format!(
-        "RUSTC=rustc {cargo_clif} build --manifest-path {manifest_path} --target-dir {target_dir}",
+        "RUSTC=rustc {cargo_clif} build --manifest-path {manifest_path} --target-dir {target_dir} && (rm build/raytracer_cg_clif || true) && ln build/simple_raytracer/debug/main build/raytracer_cg_clif",
+        cargo_clif = cargo_clif.display(),
+        manifest_path = manifest_path.display(),
+        target_dir = target_dir.display(),
+    );
+    let clif_build_opt_cmd = format!(
+        "RUSTC=rustc {cargo_clif} build --manifest-path {manifest_path} --target-dir {target_dir} --release && (rm build/raytracer_cg_clif_opt || true) && ln build/simple_raytracer/release/main build/raytracer_cg_clif_opt",
         cargo_clif = cargo_clif.display(),
         manifest_path = manifest_path.display(),
         target_dir = target_dir.display(),
     );
 
-    let bench_compile =
-        hyperfine_command(1, bench_runs, Some(&clean_cmd), &[&llvm_build_cmd, &clif_build_cmd]);
+    let bench_compile = hyperfine_command(
+        1,
+        bench_runs,
+        Some(&clean_cmd),
+        &[&llvm_build_cmd, &clif_build_cmd, &clif_build_opt_cmd],
+    );
 
     spawn_and_wait(bench_compile);
 
     eprintln!("[BENCH RUN] ebobby/simple-raytracer");
-    fs::copy(
-        target_dir.join("debug").join(get_file_name("main", "bin")),
-        RelPath::BUILD.to_path(dirs).join(get_file_name("raytracer_cg_clif", "bin")),
-    )
-    .unwrap();
 
     let mut bench_run = hyperfine_command(
         0,
@@ -98,6 +77,7 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
         &[
             Path::new(".").join(get_file_name("raytracer_cg_llvm", "bin")).to_str().unwrap(),
             Path::new(".").join(get_file_name("raytracer_cg_clif", "bin")).to_str().unwrap(),
+            Path::new(".").join(get_file_name("raytracer_cg_clif_opt", "bin")).to_str().unwrap(),
         ],
     );
     bench_run.current_dir(RelPath::BUILD.to_path(dirs));

--- a/build_system/bench.rs
+++ b/build_system/bench.rs
@@ -80,7 +80,7 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
     );
 
     let bench_compile =
-        hyperfine_command(1, bench_runs, Some(&clean_cmd), &llvm_build_cmd, &clif_build_cmd);
+        hyperfine_command(1, bench_runs, Some(&clean_cmd), &[&llvm_build_cmd, &clif_build_cmd]);
 
     spawn_and_wait(bench_compile);
 
@@ -95,8 +95,10 @@ fn benchmark_simple_raytracer(dirs: &Dirs, bootstrap_host_compiler: &Compiler) {
         0,
         bench_runs,
         None,
-        Path::new(".").join(get_file_name("raytracer_cg_llvm", "bin")).to_str().unwrap(),
-        Path::new(".").join(get_file_name("raytracer_cg_clif", "bin")).to_str().unwrap(),
+        &[
+            Path::new(".").join(get_file_name("raytracer_cg_llvm", "bin")).to_str().unwrap(),
+            Path::new(".").join(get_file_name("raytracer_cg_clif", "bin")).to_str().unwrap(),
+        ],
     );
     bench_run.current_dir(RelPath::BUILD.to_path(dirs));
     spawn_and_wait(bench_run);

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -187,7 +187,7 @@ pub(crate) fn main() {
                 &bootstrap_host_compiler,
                 target_triple,
             );
-            bench::benchmark(&dirs, &bootstrap_host_compiler);
+            bench::benchmark(&dirs);
         }
     }
 }

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -162,8 +162,7 @@ pub(crate) fn hyperfine_command(
     warmup: u64,
     runs: u64,
     prepare: Option<&str>,
-    a: &str,
-    b: &str,
+    cmds: &[&str],
 ) -> Command {
     let mut bench = Command::new("hyperfine");
 
@@ -179,7 +178,7 @@ pub(crate) fn hyperfine_command(
         bench.arg("--prepare").arg(prepare);
     }
 
-    bench.arg(a).arg(b);
+    bench.args(cmds);
 
     bench
 }


### PR DESCRIPTION
When enabling optimizations for cg_clif there is a non-trivial runtime perf improvement at a very small compile time cost. This is probably due to a combination of MIR inlining and Cranelift's [e-graph based optimizations](https://bytecodealliance.org/articles/cranelift-progress-2022#mid-end-optimizer-acyclic-e-graphs-and-isle-rewrites).

On AArch64 I'm getting a ~30% improvement over optimizations disabled for cg_clif:

<details>

```
Benchmark 1: ./raytracer_cg_llvm
  Time (mean ± σ):      7.049 s ±  0.022 s    [User: 7.041 s, System: 0.008 s]
  Range (min … max):    7.021 s …  7.097 s    10 runs
 
Benchmark 2: ./raytracer_cg_clif
  Time (mean ± σ):      4.923 s ±  0.006 s    [User: 4.917 s, System: 0.006 s]
  Range (min … max):    4.913 s …  4.931 s    10 runs
 
Benchmark 3: ./raytracer_cg_clif_opt
  Time (mean ± σ):      3.780 s ±  0.011 s    [User: 3.775 s, System: 0.006 s]
  Range (min … max):    3.770 s …  3.810 s    10 runs
 
Summary
  './raytracer_cg_clif_opt' ran
    1.30 ± 0.00 times faster than './raytracer_cg_clif'
    1.86 ± 0.01 times faster than './raytracer_cg_llvm'
```

</details>

at a small compile time cost that almost entirely vanishes due to the huge amount of available parallelism on the AArch64 machine:

<details>

```
Benchmark 1: RUSTC=rustc cargo build [...]
  Time (mean ± σ):     11.398 s ±  0.127 s    [User: 37.814 s, System: 5.434 s]
  Range (min … max):   11.150 s … 11.579 s    10 runs
 
Benchmark 2: RUSTC=rustc /home/gh-bjorn3/cg_clif/./dist/cargo-clif build [...]
  Time (mean ± σ):      9.758 s ±  0.124 s    [User: 24.436 s, System: 5.305 s]
  Range (min … max):    9.588 s … 10.033 s    10 runs
 
Benchmark 3: RUSTC=rustc /home/gh-bjorn3/cg_clif/./dist/cargo-clif build --release [...]
  Time (mean ± σ):      9.741 s ±  0.212 s    [User: 26.540 s, System: 5.244 s]
  Range (min … max):    9.564 s … 10.314 s    10 runs
 
Summary
  'RUSTC=rustc /home/gh-bjorn3/cg_clif/./dist/cargo-clif build --release [...]' ran
    1.00 ± 0.03 times faster than 'RUSTC=rustc /home/gh-bjorn3/cg_clif/./dist/cargo-clif build [...]
    1.17 ± 0.03 times faster than 'RUSTC=rustc cargo build [...]'
```

</details>

On github actions (x86_64) which has much less available parallelism I get somewhat smaller but still really nice perf improvement of ~20%:

<details>

```
Benchmark 1: ./raytracer_cg_llvm
  Time (mean ± σ):      4.294 s ±  0.053 s    [User: 4.287 s, System: 0.005 s]
  Range (min … max):    4.241 s …  4.382 s    10 runs
 
Benchmark 2: ./raytracer_cg_clif
  Time (mean ± σ):      4.095 s ±  0.058 s    [User: 4.089 s, System: 0.005 s]
  Range (min … max):    4.019 s …  4.199 s    10 runs
 
Benchmark 3: ./raytracer_cg_clif_opt
  Time (mean ± σ):      3.385 s ±  0.083 s    [User: 3.380 s, System: 0.003 s]
  Range (min … max):    3.323 s …  3.606 s    10 runs
 
Summary
  './raytracer_cg_clif_opt' ran
    1.21 ± 0.03 times faster than './raytracer_cg_clif'
    1.27 ± 0.03 times faster than './raytracer_cg_llvm'
```

</details>

At the cost of ~6% slower compilation:

<details>

```
Benchmark 1: RUSTC=rustc cargo build [...]
  Time (mean ± σ):     14.992 s ±  0.143 s    [User: 23.646 s, System: 3.589 s]
  Range (min … max):   14.815 s … 15.209 s    10 runs
 
Benchmark 2: RUSTC=rustc /home/runner/work/rustc_codegen_cranelift/rustc_codegen_cranelift/./dist/cargo-clif build [...]
  Time (mean ± σ):     10.955 s ±  0.054 s    [User: 16.081 s, System: 3.422 s]
  Range (min … max):   10.889 s … 11.044 s    10 runs
 
Benchmark 3: RUSTC=rustc /home/runner/work/rustc_codegen_cranelift/rustc_codegen_cranelift/./dist/cargo-clif build --release [...]
  Time (mean ± σ):     11.632 s ±  0.117 s    [User: 17.578 s, System: 3.311 s]
  Range (min … max):   11.468 s … 11.883 s    10 runs
 
Summary
  'RUSTC=rustc /home/runner/work/rustc_codegen_cranelift/rustc_codegen_cranelift/./dist/cargo-clif build [...]' ran
[BENCH RUN] ebobby/simple-raytracer
    1.06 ± 0.01 times faster than 'RUSTC=rustc /home/runner/work/rustc_codegen_cranelift/rustc_codegen_cranelift/./dist/cargo-clif build --release [...]'
    1.37 ± 0.01 times faster than 'RUSTC=rustc cargo build [...]'
```

</details>

Be aware however that this is for a single benchmark which is not all that representative of real life performance. Make sure to benchmark yourself on your workload. I did love to hear what the results would be for you.