### PR TITLE
Allow building and testing without rustup

### DIFF
--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -19,7 +19,6 @@ pub(crate) fn run(
     bootstrap_host_compiler: &Compiler,
 ) {
     ABI_CAFE_REPO.fetch(dirs);
-    spawn_and_wait(ABI_CAFE.fetch("cargo", &bootstrap_host_compiler.rustc, dirs));
 
     eprintln!("Building sysroot for abi-cafe");
     build_sysroot::build_sysroot(

--- a/build_system/abi_cafe.rs
+++ b/build_system/abi_cafe.rs
@@ -16,6 +16,7 @@ pub(crate) fn run(
     sysroot_kind: SysrootKind,
     dirs: &Dirs,
     cg_clif_dylib: &Path,
+    rustup_toolchain_name: Option<&str>,
     bootstrap_host_compiler: &Compiler,
 ) {
     ABI_CAFE_REPO.fetch(dirs);
@@ -27,6 +28,7 @@ pub(crate) fn run(
         sysroot_kind,
         cg_clif_dylib,
         bootstrap_host_compiler,
+        rustup_toolchain_name,
         bootstrap_host_compiler.triple.clone(),
     );
 

--- a/build_system/build_backend.rs
+++ b/build_system/build_backend.rs
@@ -52,5 +52,5 @@ pub(crate) fn build_backend(
         .target_dir(dirs)
         .join(&bootstrap_host_compiler.triple)
         .join(channel)
-        .join(get_file_name("rustc_codegen_cranelift", "dylib"))
+        .join(get_file_name(&bootstrap_host_compiler.rustc, "rustc_codegen_cranelift", "dylib"))
 }

--- a/build_system/build_sysroot.rs
+++ b/build_system/build_sysroot.rs
@@ -40,7 +40,7 @@ pub(crate) fn build_sysroot(
     try_hard_link(cg_clif_dylib_src, &cg_clif_dylib_path);
 
     // Build and copy rustc and cargo wrappers
-    let wrapper_base_name = get_file_name("____", "bin");
+    let wrapper_base_name = get_file_name(&bootstrap_host_compiler.rustc, "____", "bin");
     let toolchain_name = get_toolchain_name();
     for wrapper in ["rustc-clif", "rustdoc-clif", "cargo-clif"] {
         let wrapper_name = wrapper_base_name.replace("____", wrapper);

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 
 use self::utils::{is_ci, is_ci_opt, Compiler};
@@ -101,12 +101,24 @@ pub(crate) fn main() {
         }
     }
 
-    let bootstrap_host_compiler = Compiler::bootstrap_with_triple(
-        std::env::var("HOST_TRIPLE")
+    let bootstrap_host_compiler = {
+        let cargo = rustc_info::get_cargo_path();
+        let rustc = rustc_info::get_rustc_path();
+        let rustdoc = rustc_info::get_rustdoc_path();
+        let triple = std::env::var("HOST_TRIPLE")
             .ok()
             .or_else(|| config::get_value("host"))
-            .unwrap_or_else(|| rustc_info::get_host_triple(Path::new("rustc"))),
-    );
+            .unwrap_or_else(|| rustc_info::get_host_triple(&rustc));
+        Compiler {
+            cargo,
+            rustc,
+            rustdoc,
+            rustflags: String::new(),
+            rustdocflags: String::new(),
+            triple,
+            runner: vec![],
+        }
+    };
     let target_triple = std::env::var("TARGET_TRIPLE")
         .ok()
         .or_else(|| config::get_value("target"))

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -103,6 +103,14 @@ pub(crate) fn main() {
         }
     }
 
+    let rustup_toolchain_name = match (env::var("CARGO"), env::var("RUSTC"), env::var("RUSTDOC")) {
+        (Ok(_), Ok(_), Ok(_)) => None,
+        (Err(_), Err(_), Err(_)) => Some(rustc_info::get_toolchain_name()),
+        _ => {
+            eprintln!("All of CARGO, RUSTC and RUSTDOC need to be set or none must be set");
+            process::exit(1);
+        }
+    };
     let bootstrap_host_compiler = {
         let cargo = rustc_info::get_cargo_path();
         let rustc = rustc_info::get_rustc_path();
@@ -173,6 +181,7 @@ pub(crate) fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
+                rustup_toolchain_name.as_deref(),
                 target_triple.clone(),
             );
         }
@@ -181,7 +190,14 @@ pub(crate) fn main() {
                 eprintln!("Abi-cafe doesn't support cross-compilation");
                 process::exit(1);
             }
-            abi_cafe::run(channel, sysroot_kind, &dirs, &cg_clif_dylib, &bootstrap_host_compiler);
+            abi_cafe::run(
+                channel,
+                sysroot_kind,
+                &dirs,
+                &cg_clif_dylib,
+                rustup_toolchain_name.as_deref(),
+                &bootstrap_host_compiler,
+            );
         }
         Command::Build => {
             build_sysroot::build_sysroot(
@@ -190,6 +206,7 @@ pub(crate) fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
+                rustup_toolchain_name.as_deref(),
                 target_triple,
             );
         }
@@ -200,6 +217,7 @@ pub(crate) fn main() {
                 sysroot_kind,
                 &cg_clif_dylib,
                 &bootstrap_host_compiler,
+                rustup_toolchain_name.as_deref(),
                 target_triple,
             );
             bench::benchmark(&dirs, &bootstrap_host_compiler);

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -149,7 +149,7 @@ pub(crate) fn main() {
     }
 
     if command == Command::Prepare {
-        prepare::prepare(&dirs);
+        prepare::prepare(&dirs, &bootstrap_host_compiler.rustc);
         process::exit(0);
     }
 

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use self::utils::{is_ci, is_ci_opt, Compiler};
@@ -105,7 +105,7 @@ pub(crate) fn main() {
         std::env::var("HOST_TRIPLE")
             .ok()
             .or_else(|| config::get_value("host"))
-            .unwrap_or_else(|| rustc_info::get_host_triple()),
+            .unwrap_or_else(|| rustc_info::get_host_triple(Path::new("rustc"))),
     );
     let target_triple = std::env::var("TARGET_TRIPLE")
         .ok()
@@ -187,7 +187,7 @@ pub(crate) fn main() {
                 &bootstrap_host_compiler,
                 target_triple,
             );
-            bench::benchmark(&dirs);
+            bench::benchmark(&dirs, &bootstrap_host_compiler);
         }
     }
 }

--- a/build_system/mod.rs
+++ b/build_system/mod.rs
@@ -78,6 +78,7 @@ pub(crate) fn main() {
     let mut channel = "release";
     let mut sysroot_kind = SysrootKind::Clif;
     let mut use_unstable_features = true;
+    let mut frozen = false;
     while let Some(arg) = args.next().as_deref() {
         match arg {
             "--out-dir" => {
@@ -96,6 +97,7 @@ pub(crate) fn main() {
                 }
             }
             "--no-unstable-features" => use_unstable_features = false,
+            "--frozen" => frozen = true,
             flag if flag.starts_with("-") => arg_error!("Unknown flag {}", flag),
             arg => arg_error!("Unexpected argument {}", arg),
         }
@@ -132,6 +134,7 @@ pub(crate) fn main() {
         download_dir: out_dir.join("download"),
         build_dir: out_dir.join("build"),
         dist_dir: out_dir.join("dist"),
+        frozen,
     };
 
     path::RelPath::BUILD.ensure_exists(&dirs);

--- a/build_system/path.rs
+++ b/build_system/path.rs
@@ -9,6 +9,7 @@ pub(crate) struct Dirs {
     pub(crate) download_dir: PathBuf,
     pub(crate) build_dir: PathBuf,
     pub(crate) dist_dir: PathBuf,
+    pub(crate) frozen: bool,
 }
 
 #[doc(hidden)]

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -12,20 +12,12 @@ use super::utils::{copy_dir_recursively, git_command, retry_spawn_and_wait, spaw
 pub(crate) fn prepare(dirs: &Dirs) {
     RelPath::DOWNLOAD.ensure_fresh(dirs);
 
-    spawn_and_wait(super::build_backend::CG_CLIF.fetch("cargo", "rustc", dirs));
-
     prepare_stdlib(dirs);
-    spawn_and_wait(super::build_sysroot::STANDARD_LIBRARY.fetch("cargo", "rustc", dirs));
-
     prepare_coretests(dirs);
-    spawn_and_wait(super::tests::LIBCORE_TESTS.fetch("cargo", "rustc", dirs));
 
     super::tests::RAND_REPO.fetch(dirs);
-    spawn_and_wait(super::tests::RAND.fetch("cargo", "rustc", dirs));
     super::tests::REGEX_REPO.fetch(dirs);
-    spawn_and_wait(super::tests::REGEX.fetch("cargo", "rustc", dirs));
     super::tests::PORTABLE_SIMD_REPO.fetch(dirs);
-    spawn_and_wait(super::tests::PORTABLE_SIMD.fetch("cargo", "rustc", dirs));
 }
 
 fn prepare_stdlib(dirs: &Dirs) {

--- a/build_system/prepare.rs
+++ b/build_system/prepare.rs
@@ -9,19 +9,19 @@ use super::rustc_info::{get_default_sysroot, get_rustc_version};
 use super::tests::LIBCORE_TESTS_SRC;
 use super::utils::{copy_dir_recursively, git_command, retry_spawn_and_wait, spawn_and_wait};
 
-pub(crate) fn prepare(dirs: &Dirs) {
+pub(crate) fn prepare(dirs: &Dirs, rustc: &Path) {
     RelPath::DOWNLOAD.ensure_fresh(dirs);
 
-    prepare_stdlib(dirs);
-    prepare_coretests(dirs);
+    prepare_stdlib(dirs, rustc);
+    prepare_coretests(dirs, rustc);
 
     super::tests::RAND_REPO.fetch(dirs);
     super::tests::REGEX_REPO.fetch(dirs);
     super::tests::PORTABLE_SIMD_REPO.fetch(dirs);
 }
 
-fn prepare_stdlib(dirs: &Dirs) {
-    let sysroot_src_orig = get_default_sysroot(Path::new("rustc")).join("lib/rustlib/src/rust");
+fn prepare_stdlib(dirs: &Dirs, rustc: &Path) {
+    let sysroot_src_orig = get_default_sysroot(rustc).join("lib/rustlib/src/rust");
     assert!(sysroot_src_orig.exists());
 
     eprintln!("[COPY] stdlib src");
@@ -36,7 +36,7 @@ fn prepare_stdlib(dirs: &Dirs) {
         &SYSROOT_SRC.to_path(dirs).join("library"),
     );
 
-    let rustc_version = get_rustc_version(Path::new("rustc"));
+    let rustc_version = get_rustc_version(rustc);
     fs::write(SYSROOT_RUSTC_VERSION.to_path(dirs), &rustc_version).unwrap();
 
     eprintln!("[GIT] init");
@@ -45,8 +45,8 @@ fn prepare_stdlib(dirs: &Dirs) {
     apply_patches(dirs, "stdlib", &SYSROOT_SRC.to_path(dirs));
 }
 
-fn prepare_coretests(dirs: &Dirs) {
-    let sysroot_src_orig = get_default_sysroot(Path::new("rustc")).join("lib/rustlib/src/rust");
+fn prepare_coretests(dirs: &Dirs, rustc: &Path) {
+    let sysroot_src_orig = get_default_sysroot(rustc).join("lib/rustlib/src/rust");
     assert!(sysroot_src_orig.exists());
 
     eprintln!("[COPY] coretests src");

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -7,9 +7,9 @@ pub(crate) fn get_rustc_version(rustc: &Path) -> String {
     String::from_utf8(version_info).unwrap()
 }
 
-pub(crate) fn get_host_triple() -> String {
+pub(crate) fn get_host_triple(rustc: &Path) -> String {
     let version_info =
-        Command::new("rustc").stderr(Stdio::inherit()).args(&["-vV"]).output().unwrap().stdout;
+        Command::new(rustc).stderr(Stdio::inherit()).args(&["-vV"]).output().unwrap().stdout;
     String::from_utf8(version_info)
         .unwrap()
         .lines()
@@ -73,8 +73,8 @@ pub(crate) fn get_default_sysroot(rustc: &Path) -> PathBuf {
     Path::new(String::from_utf8(default_sysroot).unwrap().trim()).to_owned()
 }
 
-pub(crate) fn get_file_name(crate_name: &str, crate_type: &str) -> String {
-    let file_name = Command::new("rustc")
+pub(crate) fn get_file_name(rustc: &Path, crate_name: &str, crate_type: &str) -> String {
+    let file_name = Command::new(rustc)
         .stderr(Stdio::inherit())
         .args(&[
             "--crate-name",

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -82,6 +82,7 @@ pub(crate) fn get_default_sysroot(rustc: &Path) -> PathBuf {
     Path::new(String::from_utf8(default_sysroot).unwrap().trim()).to_owned()
 }
 
+// FIXME call once for each target and pass result around in struct
 pub(crate) fn get_file_name(rustc: &Path, crate_name: &str, crate_type: &str) -> String {
     let file_name = Command::new(rustc)
         .stderr(Stdio::inherit())

--- a/build_system/rustc_info.rs
+++ b/build_system/rustc_info.rs
@@ -34,6 +34,9 @@ pub(crate) fn get_toolchain_name() -> String {
 }
 
 pub(crate) fn get_cargo_path() -> PathBuf {
+    if let Ok(cargo) = std::env::var("CARGO") {
+        return PathBuf::from(cargo);
+    }
     let cargo_path = Command::new("rustup")
         .stderr(Stdio::inherit())
         .args(&["which", "cargo"])
@@ -44,6 +47,9 @@ pub(crate) fn get_cargo_path() -> PathBuf {
 }
 
 pub(crate) fn get_rustc_path() -> PathBuf {
+    if let Ok(rustc) = std::env::var("RUSTC") {
+        return PathBuf::from(rustc);
+    }
     let rustc_path = Command::new("rustup")
         .stderr(Stdio::inherit())
         .args(&["which", "rustc"])
@@ -54,6 +60,9 @@ pub(crate) fn get_rustc_path() -> PathBuf {
 }
 
 pub(crate) fn get_rustdoc_path() -> PathBuf {
+    if let Ok(rustdoc) = std::env::var("RUSTDOC") {
+        return PathBuf::from(rustdoc);
+    }
     let rustc_path = Command::new("rustup")
         .stderr(Stdio::inherit())
         .args(&["which", "rustdoc"])

--- a/build_system/tests.rs
+++ b/build_system/tests.rs
@@ -217,6 +217,7 @@ pub(crate) fn run_tests(
     sysroot_kind: SysrootKind,
     cg_clif_dylib: &Path,
     bootstrap_host_compiler: &Compiler,
+    rustup_toolchain_name: Option<&str>,
     target_triple: String,
 ) {
     if config::get_bool("testsuite.no_sysroot") {
@@ -226,6 +227,7 @@ pub(crate) fn run_tests(
             SysrootKind::None,
             cg_clif_dylib,
             bootstrap_host_compiler,
+            rustup_toolchain_name,
             target_triple.clone(),
         );
 
@@ -251,6 +253,7 @@ pub(crate) fn run_tests(
             sysroot_kind,
             cg_clif_dylib,
             bootstrap_host_compiler,
+            rustup_toolchain_name,
             target_triple.clone(),
         );
         // Rust's build system denies a couple of lints that trigger on several of the test

--- a/build_system/usage.txt
+++ b/build_system/usage.txt
@@ -2,10 +2,10 @@ The build system of cg_clif.
 
 USAGE:
     ./y.rs prepare [--out-dir DIR]
-    ./y.rs build [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-    ./y.rs test [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-    ./y.rs abi-cafe [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
-    ./y.rs bench [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features]
+    ./y.rs build [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features] [--frozen]
+    ./y.rs test [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features] [--frozen]
+    ./y.rs abi-cafe [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features] [--frozen]
+    ./y.rs bench [--debug] [--sysroot none|clif|llvm] [--out-dir DIR] [--no-unstable-features] [--frozen]
 
 OPTIONS:
     --debug
@@ -25,6 +25,9 @@ OPTIONS:
     --no-unstable-features
             Some features are not yet ready for production usage. This option will disable these
             features. This includes the JIT mode and inline assembly support.
+
+    --frozen
+            Require Cargo.lock and cache are up to date
 
 REQUIREMENTS:
     * Rustup: The build system has a hard coded dependency on rustup to install the right nightly

--- a/build_system/usage.txt
+++ b/build_system/usage.txt
@@ -30,8 +30,9 @@ OPTIONS:
             Require Cargo.lock and cache are up to date
 
 REQUIREMENTS:
-    * Rustup: The build system has a hard coded dependency on rustup to install the right nightly
-      version and make sure it is used where necessary.
+    * Rustup: By default rustup is used to install the right nightly version. If you don't want to
+      use rustup, you can manually install the nightly version indicated by rust-toolchain.toml and
+      point the CARGO, RUSTC and RUSTDOC env vars to the right executables.
     * Git: `./y.rs prepare` uses git for applying patches and on Windows for downloading test repos.
     * Curl and tar (non-Windows only): Used by `./y.rs prepare` to download a single commit for
       repos. Git will be used to clone the whole repo when using Windows.

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 
 use super::path::{Dirs, RelPath};
-use super::rustc_info::{get_cargo_path, get_rustc_path, get_rustdoc_path};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Compiler {
@@ -19,18 +18,6 @@ pub(crate) struct Compiler {
 }
 
 impl Compiler {
-    pub(crate) fn bootstrap_with_triple(triple: String) -> Compiler {
-        Compiler {
-            cargo: get_cargo_path(),
-            rustc: get_rustc_path(),
-            rustdoc: get_rustdoc_path(),
-            rustflags: String::new(),
-            rustdocflags: String::new(),
-            triple,
-            runner: vec![],
-        }
-    }
-
     pub(crate) fn set_cross_linker_and_runner(&mut self) {
         match self.triple.as_str() {
             "aarch64-unknown-linux-gnu" => {

--- a/build_system/utils.rs
+++ b/build_system/utils.rs
@@ -81,8 +81,11 @@ impl CargoProject {
             .arg("--manifest-path")
             .arg(self.manifest_path(dirs))
             .arg("--target-dir")
-            .arg(self.target_dir(dirs))
-            .arg("--frozen");
+            .arg(self.target_dir(dirs));
+
+        if dirs.frozen {
+            cmd.arg("--frozen");
+        }
 
         cmd
     }
@@ -103,23 +106,6 @@ impl CargoProject {
                 compiler.runner.join(" "),
             );
         }
-
-        cmd
-    }
-
-    #[must_use]
-    pub(crate) fn fetch(
-        &self,
-        cargo: impl AsRef<Path>,
-        rustc: impl AsRef<Path>,
-        dirs: &Dirs,
-    ) -> Command {
-        let mut cmd = Command::new(cargo.as_ref());
-
-        cmd.env("RUSTC", rustc.as_ref())
-            .arg("fetch")
-            .arg("--manifest-path")
-            .arg(self.manifest_path(dirs));
 
         cmd
     }

--- a/scripts/cargo-clif.rs
+++ b/scripts/cargo-clif.rs
@@ -28,8 +28,13 @@ fn main() {
     env::set_var("RUSTFLAGS", env::var("RUSTFLAGS").unwrap_or(String::new()) + &rustflags);
     env::set_var("RUSTDOCFLAGS", env::var("RUSTDOCFLAGS").unwrap_or(String::new()) + &rustflags);
 
-    // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
+    let cargo = if let Some(cargo) = option_env!("CARGO") {
+        cargo
+    } else {
+        // Ensure that the right toolchain is used
+        env::set_var("RUSTUP_TOOLCHAIN", option_env!("TOOLCHAIN_NAME").expect("TOOLCHAIN_NAME"));
+        "cargo"
+    };
 
     let args: Vec<_> = match env::args().nth(1).as_deref() {
         Some("jit") => {
@@ -64,10 +69,10 @@ fn main() {
     };
 
     #[cfg(unix)]
-    panic!("Failed to spawn cargo: {}", Command::new("cargo").args(args).exec());
+    panic!("Failed to spawn cargo: {}", Command::new(cargo).args(args).exec());
 
     #[cfg(not(unix))]
     std::process::exit(
-        Command::new("cargo").args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
+        Command::new(cargo).args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
     );
 }

--- a/scripts/rustc-clif.rs
+++ b/scripts/rustc-clif.rs
@@ -30,14 +30,19 @@ fn main() {
     }
     args.extend(passed_args);
 
-    // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
+    let rustc = if let Some(rustc) = option_env!("RUSTC") {
+        rustc
+    } else {
+        // Ensure that the right toolchain is used
+        env::set_var("RUSTUP_TOOLCHAIN", option_env!("TOOLCHAIN_NAME").expect("TOOLCHAIN_NAME"));
+        "rustc"
+    };
 
     #[cfg(unix)]
-    panic!("Failed to spawn rustc: {}", Command::new("rustc").args(args).exec());
+    panic!("Failed to spawn rustc: {}", Command::new(rustc).args(args).exec());
 
     #[cfg(not(unix))]
     std::process::exit(
-        Command::new("rustc").args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
+        Command::new(rustc).args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
     );
 }

--- a/scripts/rustdoc-clif.rs
+++ b/scripts/rustdoc-clif.rs
@@ -30,14 +30,19 @@ fn main() {
     }
     args.extend(passed_args);
 
-    // Ensure that the right toolchain is used
-    env::set_var("RUSTUP_TOOLCHAIN", env!("TOOLCHAIN_NAME"));
+    let rustdoc = if let Some(rustdoc) = option_env!("RUSTDOC") {
+        rustdoc
+    } else {
+        // Ensure that the right toolchain is used
+        env::set_var("RUSTUP_TOOLCHAIN", option_env!("TOOLCHAIN_NAME").expect("TOOLCHAIN_NAME"));
+        "rustdoc"
+    };
 
     #[cfg(unix)]
-    panic!("Failed to spawn rustdoc: {}", Command::new("rustdoc").args(args).exec());
+    panic!("Failed to spawn rustdoc: {}", Command::new(rustdoc).args(args).exec());
 
     #[cfg(not(unix))]
     std::process::exit(
-        Command::new("rustdoc").args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
+        Command::new(rustdoc).args(args).spawn().unwrap().wait().unwrap().code().unwrap_or(1),
     );
 }


### PR DESCRIPTION
This can be done by installing the nightly specified in rust-toolchain.toml and then pointing the `CARGO`, `RUSTC` and `RUSTDOC` env vars to the right executables.